### PR TITLE
`36` fix: feed api 수정

### DIFF
--- a/src/main/java/com/sixpack/dorundorun/feature/feed/api/SelfieApi.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/api/SelfieApi.java
@@ -50,7 +50,7 @@ public interface SelfieApi {
 		@Parameter(hidden = true) @CurrentUser User user,
 
 		@Parameter(
-			description = "인증 데이터",
+			description = "인증 데이터 -> CreateSelfieRequest",
 			required = true,
 			schema = @io.swagger.v3.oas.annotations.media.Schema(
 				implementation = CreateSelfieRequest.class,

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/api/SelfieApi.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/api/SelfieApi.java
@@ -2,7 +2,6 @@ package com.sixpack.dorundorun.feature.feed.api;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
@@ -84,7 +83,6 @@ public interface SelfieApi {
 		@ApiResponse(responseCode = "404", description = "셀피를 찾을 수 없습니다")
 	})
 	DorunResponse<SelfieReactionResponse> reactToSelfie(
-		@Parameter(description = "셀피 ID", required = true) @PathVariable Long selfieId,
 		@Parameter(hidden = true) @CurrentUser User user,
 		@Valid @RequestBody SelfieReactionRequest request
 	);

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/api/SelfieController.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/api/SelfieController.java
@@ -3,7 +3,6 @@ package com.sixpack.dorundorun.feature.feed.api;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -81,9 +80,8 @@ public class SelfieController implements SelfieApi {
 	}
 
 	@Override
-	@PostMapping("/feeds/{selfieId}/reaction")
+	@PostMapping("/feeds/reaction")
 	public DorunResponse<SelfieReactionResponse> reactToSelfie(
-		@PathVariable Long selfieId,
 		@CurrentUser User user,
 		@Valid @RequestBody SelfieReactionRequest request
 	) {

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/application/FindAllFeedsWithReactionsByUserIdAndDateRangeService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/application/FindAllFeedsWithReactionsByUserIdAndDateRangeService.java
@@ -21,10 +21,10 @@ public class FindAllFeedsWithReactionsByUserIdAndDateRangeService {
 	private final FeedJpaRepository feedJpaRepository;
 
 	@Transactional(readOnly = true)
-	public Page<Feed> find(Long userId, Long currentUserId, boolean isFriendFeed, LocalDateTime startOfDay,
+	public Page<Feed> find(Long userId, Long currentUserId, LocalDateTime startOfDay,
 		LocalDateTime endOfDay, Pageable pageable) {
 		return feedJpaRepository.findByUserIdAndDateRangeWithReactions(
-			userId, currentUserId, isFriendFeed, startOfDay, endOfDay, pageable
+			userId, currentUserId, startOfDay, endOfDay, pageable
 		);
 	}
 }

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/dao/FeedJpaRepository.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/dao/FeedJpaRepository.java
@@ -22,28 +22,29 @@ public interface FeedJpaRepository extends JpaRepository<Feed, Long> {
 		JOIN FETCH f.user
 		JOIN FETCH f.runSession
 		LEFT JOIN Friend fr ON fr.friend.id = f.user.id AND fr.user.id = :currentUserId AND fr.deletedAt IS NULL
-		WHERE (:userId IS NULL AND :isFriendFeed = true AND fr.id IS NOT NULL)
-		OR (:userId IS NULL AND :isFriendFeed = false)
-		OR (:userId IS NOT NULL AND f.user.id = :userId)
+		WHERE f.deletedAt IS NULL
 		AND (:startDate IS NULL OR f.createdAt >= :startDate)
 		AND (:endDate IS NULL OR f.createdAt <= :endDate)
-		AND f.deletedAt IS NULL
+		AND (
+			(:userId IS NULL AND (fr.id IS NOT NULL OR f.user.id = :currentUserId))
+			OR (:userId IS NOT NULL AND f.user.id = :userId)
+		)
 		ORDER BY f.createdAt DESC
 		""",
 		countQuery = """
 			SELECT COUNT(f) FROM Feed f
 			LEFT JOIN Friend fr ON fr.friend.id = f.user.id AND fr.user.id = :currentUserId AND fr.deletedAt IS NULL
-			WHERE (:userId IS NULL AND :isFriendFeed = true AND fr.id IS NOT NULL)
-			OR (:userId IS NULL AND :isFriendFeed = false)
-			OR (:userId IS NOT NULL AND f.user.id = :userId)
+			WHERE f.deletedAt IS NULL
 			AND (:startDate IS NULL OR f.createdAt >= :startDate)
 			AND (:endDate IS NULL OR f.createdAt <= :endDate)
-			AND f.deletedAt IS NULL
+			AND (
+				(:userId IS NULL AND (fr.id IS NOT NULL OR f.user.id = :currentUserId))
+				OR (:userId IS NOT NULL AND f.user.id = :userId)
+			)
 			""")
 	Page<Feed> findByUserIdAndDateRangeWithReactions(
 		@Param("userId") Long userId,
 		@Param("currentUserId") Long currentUserId,
-		@Param("isFriendFeed") boolean isFriendFeed,
 		@Param("startDate") LocalDateTime startDate,
 		@Param("endDate") LocalDateTime endDate,
 		Pageable pageable

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/domain/EmojiType.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/domain/EmojiType.java
@@ -6,12 +6,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum EmojiType {
-	THUMBS_UP("👍", "좋아요"),
-	CLAP("👏", "박수"),
-	FIRE("🔥", "불타는"),
-	HEART("❤️", "하트"),
-	MUSCLE("💪", "힘내");
+	SURPRISE("놀람"),
+	HEART("하트"),
+	THUMBS_UP("따봉"),
+	CONGRATS("축하"),
+	FIRE("불");
 
-	private final String emoji;
 	private final String description;
 }

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/dto/request/SelfieReactionRequest.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/dto/request/SelfieReactionRequest.java
@@ -1,13 +1,19 @@
 package com.sixpack.dorundorun.feature.feed.dto.request;
 
+import com.sixpack.dorundorun.feature.feed.domain.EmojiType;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "셀피 반응 요청")
 public record SelfieReactionRequest(
 
-	@Schema(description = "이모지 타입 (예: FIRE, CLAP, HEART 등)", example = "FIRE")
+	@Schema(description = "피드 ID", example = "123")
+	@NotNull(message = "피드 ID는 필수입니다.")
+	Long feedId,
+
+	@Schema(description = "이모지 타입 (예: FIRE, SURPRISE, HEART 등)", example = "FIRE")
 	@NotNull(message = "이모지 타입은 필수입니다.")
-	String emojiType
+	EmojiType emojiType
 ) {
 }

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/dto/response/SelfieFeedResponse.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/dto/response/SelfieFeedResponse.java
@@ -22,6 +22,9 @@ public record SelfieFeedResponse(
 		@Schema(description = "유저 이름", example = "닉네임")
 		String name,
 
+		@Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+		String profileImageUrl,
+
 		@Schema(description = "친구 수", example = "7")
 		Integer friendCount,
 
@@ -47,6 +50,9 @@ public record SelfieFeedResponse(
 		@Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
 		String profileImageUrl,
 
+		@Schema(description = "내 피드 여부", example = "true")
+		Boolean isMyFeed,
+
 		@Schema(description = "인증 시간", example = "2025-09-20T23:58:00")
 		LocalDateTime selfieTime,
 
@@ -69,18 +75,20 @@ public record SelfieFeedResponse(
 		List<ReactionSummary> reactions
 	) {
 
-		public static FeedItem of(Feed feed, List<ReactionSummary> summaries) {
+		public static FeedItem of(Feed feed, List<ReactionSummary> summaries, Long currentUserId,
+		                          String profileImageUrl, String selfieImageUrl) {
 			return new FeedItem(
 				feed.getId(),
 				feed.getCreatedAt().toLocalDate().toString(),
 				feed.getUser().getNickname(),
-				feed.getUser().getProfileImageUrl(),
+				profileImageUrl,
+				feed.getUser().getId().equals(currentUserId),
 				feed.getCreatedAt(),
 				feed.getRunSession().getDistanceTotal(),
 				feed.getRunSession().getDurationTotal(),
 				feed.getRunSession().getPaceAvg(),
 				feed.getRunSession().getCadenceAvg(),
-				feed.getSelfieImageUrl(),
+				selfieImageUrl,
 				summaries
 			);
 		}
@@ -110,6 +118,9 @@ public record SelfieFeedResponse(
 		@Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/profiles/user123.jpg")
 		String profileImageUrl,
 
+		@Schema(description = "내 반응 여부", example = "true")
+		Boolean isMe,
+
 		@Schema(description = "반응 시간", example = "2025-10-16T14:30:00")
 		LocalDateTime reactedAt
 	) {
@@ -119,6 +130,7 @@ public record SelfieFeedResponse(
 				reaction.getUser().getId(),
 				reaction.getUser().getNickname(),
 				reaction.getUser().getProfileImageUrl(),
+				null,  // isMe는 서비스 레이어에서 설정
 				reaction.getCreatedAt()
 			);
 		}

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/dto/response/SelfieWeekResponse.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/dto/response/SelfieWeekResponse.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record SelfieWeekResponse(
 
 	@Schema(description = "날짜별 인증 수 목록")
-	List<DailyCertification> data
+	List<DailyCertification> countList
 ) {
 	@Schema(description = "일별 인증 정보")
 	public record DailyCertification(


### PR DESCRIPTION
 ---
  🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

  - closed #63

  셀피 피드 API의 응답 구조를 개선하고 이미지 URL 처리 방식을 보완합니다:
  - 클라이언트에서 내 피드/반응 여부를 판별할 수 있는 플래그 부재
  - 이미지 URL이 S3 key 그대로 노출되어 보안 취약
  - 프로필 이미지 null 시 기본 이미지 미제공
  - 친구 피드 조회 시 내 피드가 누락되는 문제

  ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

  1. 피드 응답 구조 개선
  - FeedItem에 isMyFeed 플래그 추가 (내 피드 여부 판별)
  - ReactionUser에 isMe 플래그 추가 (내 반응 여부 표시)
  - UserSummary에 profileImageUrl 추가

  2. 이미지 URL 보안 강화
  - 모든 이미지 URL을 S3 Presigned URL로 변환
  - 프로필 이미지가 null일 경우 기본 이미지 URL 반환

  3. 쿼리 로직 수정
  - 친구 피드 조회 시 내 피드도 함께 조회되도록 개선
  - 불필요한 isFriendFeed 파라미터 제거로 코드 간소화

  🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

  - SelfieWeekResponse의 필드명 변경: data → countList (명확성 개선)

  🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

  🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

  ---
  📝 Assignee를 위한 CheckList

  - 셀피 피드 응답에 isMyFeed, isMe 플래그 추가
  - 모든 이미지 URL을 S3 Presigned URL로 변환
  - 프로필 이미지 null 시 기본 이미지 URL 반환 로직 추가
  - 친구 피드 조회 시 내 피드도 포함되도록 쿼리 수정
  - 불필요한 isFriendFeed 파라미터 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 피드에 프로필 이미지가 표시됩니다(저장된 이미지 또는 기본 이미지 자동 대체).
  * 자신이 작성한 피드(isMyFeed)와 자신의 반응 여부(isMe)를 표시합니다.

* **변경 사항**
  * 반응 요청 형식이 변경되어 대상 피드 선택(feedId)과 열거형 이모지(새 이모지 세트)를 사용합니다.
  * 반응 API 경로가 단순화되어 경로 매개변수가 제거되었습니다.
  * 주간 응답 필드명이 data에서 countList로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->