### PR TITLE
feat: run 러닝 세션 목록 조회시 endDate 필터 추가

### DIFF
--- a/src/main/java/com/sixpack/dorundorun/feature/run/application/FindAllRunSessionsService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/run/application/FindAllRunSessionsService.java
@@ -25,7 +25,8 @@ public class FindAllRunSessionsService {
 		List<RunSessionWithFeedProjection> results = runSessionJpaRepository.findAllBySelfiedStatusAndStartDateTime(
 			userId,
 			request.isSelfied(),
-			request.startDateTime()
+			request.startDateTime(),
+			request.endDateTime()
 		);
 
 		return results.stream()

--- a/src/main/java/com/sixpack/dorundorun/feature/run/dao/RunSessionJpaRepository.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/run/dao/RunSessionJpaRepository.java
@@ -36,6 +36,10 @@ public interface RunSessionJpaRepository extends JpaRepository<RunSession, Long>
 			 OR rs.createdAt >= :startDateTime
 		 )
 		 AND (
+			 :endDateTime IS NULL
+			 OR rs.createdAt <= :endDateTime
+		 )
+		 AND (
 			 :isSelfied IS NULL
 			 OR(:isSelfied = true AND f.id IS NOT NULL)
 		     OR (:isSelfied = false AND f.id IS NULL)
@@ -45,7 +49,8 @@ public interface RunSessionJpaRepository extends JpaRepository<RunSession, Long>
 	List<RunSessionWithFeedProjection> findAllBySelfiedStatusAndStartDateTime(
 		@Param("userId") Long userId,
 		@Param("isSelfied") Boolean isSelfied,
-		@Param("startDateTime") LocalDateTime startDateTime
+		@Param("startDateTime") LocalDateTime startDateTime,
+		@Param("endDateTime") LocalDateTime endDateTime
 	);
 
 	Optional<RunSession> findByIdAndUserId(Long id, Long userId);

--- a/src/main/java/com/sixpack/dorundorun/feature/run/dto/request/RunSessionListRequest.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/run/dto/request/RunSessionListRequest.java
@@ -10,6 +10,9 @@ public record RunSessionListRequest(
 	Boolean isSelfied,
 
 	@Schema(description = "조회 시작 시간 (이 시간 이후 생성된 세션)", example = "2024-01-15T09:00:00", nullable = true)
-	LocalDateTime startDateTime
+	LocalDateTime startDateTime,
+
+	@Schema(description = "조회 끝 시간", example = "2024-01-17T09:00:00", nullable = true)
+	LocalDateTime endDateTime
 ) {
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

* 러닝 세션 목록 조회시 endDate 필터 추가

<img width="590" height="1278" alt="스크린샷, 2025-11-05 23 17 04" src="https://github.com/user-attachments/assets/364a59fc-da4c-44a0-b65d-e7bc820a65e7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 런 세션 검색 요청에 종료 날짜 필드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->