### PR TITLE
fix: default profile image url response

### DIFF
--- a/src/main/java/com/sixpack/dorundorun/feature/friend/application/FriendsRunningStatusService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/friend/application/FriendsRunningStatusService.java
@@ -16,6 +16,7 @@ import com.sixpack.dorundorun.feature.user.application.GetDefaultProfileImageUrl
 import com.sixpack.dorundorun.global.config.webclient.naver.ReverseGeocodingProperties;
 import com.sixpack.dorundorun.global.response.PaginationResponse;
 import com.sixpack.dorundorun.infra.naver.dto.AddressInfo;
+import com.sixpack.dorundorun.infra.s3.S3Service;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,6 +29,7 @@ public class FriendsRunningStatusService {
 	private final CoordinateAddressService coordinateAddressService;
 	private final GetDefaultProfileImageUrlService getDefaultProfileImageUrlService;
 	private final ReverseGeocodingProperties reverseGeocodingProperties;
+	private final S3Service s3Service;
 
 	@Transactional(readOnly = true)
 	public PaginationResponse<FriendRunningStatusResponse> find(Long userId, Integer page, Integer size) {
@@ -83,9 +85,10 @@ public class FriendsRunningStatusService {
 		CoordinateAddressService.CoordinateData coordinates,
 		LocalDateTime latestCheeredAt) {
 
-		String profileImageUrl = projection.getProfileImage() != null
-			? projection.getProfileImage()
-			: getDefaultProfileImageUrlService.get();
+		String profileImageUrl =
+			projection.getProfileImage() != null
+				? s3Service.getImageUrl(projection.getProfileImage())
+				: getDefaultProfileImageUrlService.get();
 
 		boolean isMe = projection.getIsMe() != null && projection.getIsMe() != 0;
 

--- a/src/main/java/com/sixpack/dorundorun/feature/friend/dao/FriendJpaRepository.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/friend/dao/FriendJpaRepository.java
@@ -30,7 +30,7 @@ public interface FriendJpaRepository extends JpaRepository<Friend, Long> {
 		SELECT u.id as userId,
 		       CASE WHEN u.id = :userId THEN 1 ELSE 0 END as isMe,
 		       u.nickname as nickname,
-		       CAST(NULL AS string) as profileImage,
+		       u.profileImageUrl as profileImage,
 		       rs.createdAt as latestRanAt,
 		       CAST(NULL AS long) as distance,
 		       CAST(NULL AS double) as latitude,
@@ -39,11 +39,11 @@ public interface FriendJpaRepository extends JpaRepository<Friend, Long> {
 		FROM User u
 		LEFT JOIN Friend f ON f.friend.id = u.id AND f.user.id = :userId AND f.deletedAt IS NULL
 		LEFT JOIN RunSegment rs ON rs.id = (
-		    SELECT rs2.id 
-		    FROM RunSegment rs2 
-		    JOIN rs2.runSession sess 
-		    WHERE sess.user.id = u.id 
-		    ORDER BY rs2.createdAt DESC 
+		    SELECT rs2.id
+		    FROM RunSegment rs2
+		    JOIN rs2.runSession sess
+		    WHERE sess.user.id = u.id
+		    ORDER BY rs2.createdAt DESC
 		    LIMIT 1
 		)
 		WHERE u.id = :userId OR f.id IS NOT NULL

--- a/src/main/java/com/sixpack/dorundorun/feature/friend/dto/response/FriendRunningStatusResponse.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/friend/dto/response/FriendRunningStatusResponse.java
@@ -15,7 +15,7 @@ public record FriendRunningStatusResponse(
 	@Schema(description = "닉네임", example = "두런이")
 	String nickname,
 
-	@Schema(description = "프로필 이미지 URL (앞에 https://api.dorundorun.store 를 붙이면 이미지 조회가 됩니다.)", example = "https://api.dorundorun.store/api/images/defaultProfileImage.jpg")
+	@Schema(description = "프로필 이미지 URL (완전한 HTTPS URL 또는 S3 Presigned URL)", example = "https://api.dorundorun.store/api/images/defaultProfileImage.jpg")
 	String profileImage,
 
 	@Schema(description = "최근 러닝 시각 (ISO 8601 형식)", example = "2025-09-13T19:57:13.000000Z")

--- a/src/main/java/com/sixpack/dorundorun/feature/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/dto/response/NotificationResponse.java
@@ -19,7 +19,7 @@ import lombok.Getter;
 		  "title": "친구 응원",
 		  "message": "이 당신을 응원합니다!",
 		  "sender": "김철수",
-		  "profileImage": "/api/images/defaultProfileImage.jpg",
+		  "profileImage": "https://api.dorundorun.store/api/images/defaultProfileImage.jpg",
 		  "type": "CHEER_FRIEND",
 		  "isRead": false,
 		  "readAt": null,
@@ -43,7 +43,7 @@ public class NotificationResponse {
 	@Schema(description = "발신자 닉네임", example = "김철수")
 	private String sender;
 
-	@Schema(description = "발신자 프로필 이미지", example = "/api/images/defaultProfileImage.jpg")
+	@Schema(description = "발신자 프로필 이미지 (완전한 HTTPS URL 또는 S3 Presigned URL)", example = "https://api.dorundorun.store/api/images/defaultProfileImage.jpg")
 	private String profileImage;
 
 	@Schema(description = "알림 유형 - 7가지 타입 지원:\n" +
@@ -74,7 +74,7 @@ public class NotificationResponse {
 		example = "123")
 	private Long relatedId;
 
-	@Schema(description = "셀피 이미지 (FEED_UPLOADED 타입일 때만 값 있음, 나머지는 null)", example = "null")
+	@Schema(description = "셀피 이미지 URL (FEED_UPLOADED, FEED_REACTION 타입일 때만 S3 Presigned URL 반환, 나머지는 null)", example = "https://s3.amazonaws.com/...")
 	private String selfieImage;
 
 	@Schema(description = "생성 시간", example = "2025-10-29T14:35:13.000000Z")

--- a/src/main/java/com/sixpack/dorundorun/feature/user/application/GetDefaultProfileImageUrlService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/user/application/GetDefaultProfileImageUrlService.java
@@ -9,7 +9,10 @@ public class GetDefaultProfileImageUrlService {
 	@Value("${app.default-profile-image-url}")
 	private String defaultProfileImageUrl;
 
+	@Value("${app.base-url}")
+	private String baseUrl;
+
 	public String get() {
-		return defaultProfileImageUrl;
+		return baseUrl + defaultProfileImageUrl;
 	}
 }

--- a/src/main/java/com/sixpack/dorundorun/feature/user/application/UpdateMyProfileService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/user/application/UpdateMyProfileService.java
@@ -24,6 +24,7 @@ public class UpdateMyProfileService {
 	private final S3Service s3Service;
 	private final ObjectMapper objectMapper;
 	private final UpdateUserProfileTransactionService transactionService;
+	private final GetDefaultProfileImageUrlService getDefaultProfileImageUrlService;
 
 	public NewProfileResponse updateProfile(User user, String dataJson, MultipartFile profileImage) {
 		MyProfileUpdateRequest request = parseRequest(dataJson);
@@ -36,10 +37,11 @@ public class UpdateMyProfileService {
 
 		deleteOldImageIfNeeded(option, currentImageUrl);
 
-		if (newImageUrl == null) {
-			return null;
-		}
-		return new NewProfileResponse(s3Service.getImageUrl(newImageUrl));
+		String responseImageUrl = newImageUrl != null
+			? s3Service.getImageUrl(newImageUrl)
+			: getDefaultProfileImageUrlService.get();
+
+		return new NewProfileResponse(responseImageUrl);
 	}
 
 	private MyProfileUpdateRequest parseRequest(String dataJson) {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,6 @@
+app:
+  base-url: http://localhost:8080
+
 spring:
   config:
     activate:


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #94 
>관련 이슈 번호를 할당해주세요
>
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요.
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

* 기존 하드코딩되어서 제대로 응답하지 않던 friend status api의 프로필이미지 응답을 제대로 작동하도록 고쳤습니다
* 추가로 알림 기능에서도 하드코딩되어있던 프로필이미지와 피드이미지 부분 수정했습니다!

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

프로필 이미지가 null 일 시에 default profile image를 도메인까지 같이 전달하도록 수정했습니다.
[fix: default profile image url response](https://github.com/depromeet/dorundorun-server/commit/f83e9217de310dd3d68ce37c68c5e73ffc9b4321)

base url 분리했습니다!
[chore: base url 분리](https://github.com/depromeet/dorundorun-server/commit/77ad24a25f3111218b9d2cc7ea1c66b00900ed1b)

newImageUrl null 일시에 default profile image 반환하도록 했습니다
[fix: newImageUrl null 일 시에 default profile image 반환](https://github.com/depromeet/dorundorun-server/commit/49d7e743f89125840d29bfd4d646e158cb91d4cc)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* yml 파일 변경된거 확인해주세용!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Refactor**
  * 프로필 이미지 및 셀피 이미지 URL 반환 처리 방식을 개선했습니다.
  * 기본 프로필 이미지 URL 구성 로직을 업데이트했습니다.

* **Documentation**
  * 친구 목록 및 알림 API 응답의 이미지 필드 문서를 S3 Presigned URL 지원을 반영하도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->