### PR TITLE
 fix: GET /api/selfie/uploadable API 관련 로직 수정 및 에러처리, 로그 관련 개선

### DIFF
--- a/src/main/java/com/sixpack/dorundorun/feature/auth/application/SignUpService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/auth/application/SignUpService.java
@@ -4,8 +4,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sixpack.dorundorun.feature.auth.dto.request.SignUpRequest;
 import com.sixpack.dorundorun.feature.auth.dto.response.SignUpResponse;
 import com.sixpack.dorundorun.feature.auth.exception.AuthErrorCode;
@@ -38,12 +36,9 @@ public class SignUpService {
 	private final RedisTokenRepository redisTokenRepository;
 	private final UserJpaRepository userJpaRepository;
 	private final RedisStreamPublisher eventPublisher;
-	private final ObjectMapper objectMapper;
 
 	@Transactional
-	public SignUpResponse signUp(String dataJson, MultipartFile profileImage) {
-		SignUpRequest request = parseRequest(dataJson);
-
+	public SignUpResponse signUp(SignUpRequest request, MultipartFile profileImage) {
 		String normalizedPhoneNumber = phoneNumberNormalizationUtil.normalize(request.phoneNumber());
 
 		validatePhoneNumberService.validate(normalizedPhoneNumber);
@@ -70,14 +65,6 @@ public class SignUpService {
 			accessToken,
 			refreshToken
 		);
-	}
-
-	private SignUpRequest parseRequest(String dataJson) {
-		try {
-			return objectMapper.readValue(dataJson, SignUpRequest.class);
-		} catch (JsonProcessingException e) {
-			throw new IllegalArgumentException("Invalid JSON format", e);
-		}
 	}
 
 	private User createUser(SignUpRequest request, String profileImageUrl, String userCode,

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/api/SelfieController.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/api/SelfieController.java
@@ -16,6 +16,8 @@ import org.springframework.web.multipart.MultipartFile;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sixpack.dorundorun.feature.feed.application.CheckSelfieUploadableService;
+import com.sixpack.dorundorun.global.exception.CustomException;
+import com.sixpack.dorundorun.global.exception.GlobalErrorCode;
 import com.sixpack.dorundorun.feature.feed.application.CreateSelfieService;
 import com.sixpack.dorundorun.feature.feed.application.DeleteSelfieService;
 import com.sixpack.dorundorun.feature.feed.application.FindAllWeeklySelfiesService;
@@ -85,7 +87,7 @@ public class SelfieController implements SelfieApi {
 
 			return DorunResponse.success("인증 업로드에 성공하였습니다");
 		} catch (JsonProcessingException e) {
-			throw new IllegalArgumentException("잘못된 JSON 형식입니다.", e);
+			throw new CustomException(GlobalErrorCode.INVALID_INPUT, "잘못된 JSON 형식입니다.");
 		}
 	}
 
@@ -136,7 +138,7 @@ public class SelfieController implements SelfieApi {
 			String selfieImageUrl = updateSelfieService.update(feedId, user, data, selfieImage);
 			return DorunResponse.success("셀피 수정에 성공하였습니다", new UpdateSelfieResponse(selfieImageUrl));
 		} catch (JsonProcessingException e) {
-			throw new IllegalArgumentException("잘못된 JSON 형식입니다.", e);
+			throw new CustomException(GlobalErrorCode.INVALID_INPUT, "잘못된 JSON 형식입니다.");
 		}
 	}
 

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/application/CheckSelfieUploadableService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/application/CheckSelfieUploadableService.java
@@ -2,7 +2,6 @@ package com.sixpack.dorundorun.feature.feed.application;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,38 +12,45 @@ import com.sixpack.dorundorun.feature.feed.dto.response.CheckSelfieUploadableRes
 import com.sixpack.dorundorun.feature.run.application.FindRunSessionByIdAndUserIdService;
 import com.sixpack.dorundorun.feature.run.domain.RunSession;
 import com.sixpack.dorundorun.feature.user.domain.User;
+import com.sixpack.dorundorun.global.utils.KoreaTimeHandler;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CheckSelfieUploadableService {
 
 	private final FindRunSessionByIdAndUserIdService findRunSessionByIdAndUserIdService;
 	private final FeedJpaRepository feedJpaRepository;
+	private final KoreaTimeHandler koreaTimeHandler;
 
 	@Transactional(readOnly = true)
 	public CheckSelfieUploadableResponse execute(User user, CheckSelfieUploadableRequest request) {
 		RunSession runSession = findRunSessionByIdAndUserIdService.find(request.runSessionId(), user.getId());
 
 		LocalDateTime runStartTime = runSession.getCreatedAt();
-		LocalDate runStartDate = runStartTime.toLocalDate();
-		LocalDate today = LocalDate.now();
+		LocalDate koreaToday = koreaTimeHandler.now();
+		LocalDate runStartKoreaDate = koreaTimeHandler.toKoreaDate(runStartTime);
+		log.info("[시간 처리 로그] 오늘 러닝인가? {}", koreaTimeHandler.isTodayInKorea(runStartTime));
 
-		if (!runStartDate.equals(today)) {
+		if (!koreaTimeHandler.isTodayInKorea(runStartTime)) {
 			return CheckSelfieUploadableResponse.notUploadable("RUN_NOT_TODAY");
 		}
 
-		LocalDateTime todayStart = today.atStartOfDay();
-		LocalDateTime todayEnd = today.atTime(LocalTime.MAX);
+		LocalDateTime todayStartInUtc = koreaTimeHandler.todayStartInUtc();
+		LocalDateTime todayEndInUtc = koreaTimeHandler.todayEndInUtc();
 
 		boolean hasUploadedToday = feedJpaRepository.findByUserIdAndDateRangeWithReactions(
 			user.getId(),
 			user.getId(),
-			todayStart,
-			todayEnd,
+			todayStartInUtc,
+			todayEndInUtc,
 			org.springframework.data.domain.PageRequest.of(0, 1)
 		).hasContent();
+
+		log.info("[시간 처리 로그] 오늘 이미 업로드했는가? {}", hasUploadedToday);
 
 		if (hasUploadedToday) {
 			return CheckSelfieUploadableResponse.notUploadable("ALREADY_UPLOADED_TODAY");

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/application/CheckSelfieUploadableService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/application/CheckSelfieUploadableService.java
@@ -1,6 +1,5 @@
 package com.sixpack.dorundorun.feature.feed.application;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
@@ -31,9 +30,7 @@ public class CheckSelfieUploadableService {
 		RunSession runSession = findRunSessionByIdAndUserIdService.find(request.runSessionId(), user.getId());
 
 		LocalDateTime runStartTime = runSession.getCreatedAt();
-		LocalDate koreaToday = koreaTimeHandler.now();
-		LocalDate runStartKoreaDate = koreaTimeHandler.toKoreaDate(runStartTime);
-		log.info("[시간 처리 로그] 오늘 러닝인가? {}", koreaTimeHandler.isTodayInKorea(runStartTime));
+		log.debug("[시간 처리 로그] 오늘 러닝인가? {}", koreaTimeHandler.isTodayInKorea(runStartTime));
 
 		if (!koreaTimeHandler.isTodayInKorea(runStartTime)) {
 			return CheckSelfieUploadableResponse.notUploadable("RUN_NOT_TODAY");
@@ -50,7 +47,7 @@ public class CheckSelfieUploadableService {
 			org.springframework.data.domain.PageRequest.of(0, 1)
 		).hasContent();
 
-		log.info("[시간 처리 로그] 오늘 이미 업로드했는가? {}", hasUploadedToday);
+		log.debug("[시간 처리 로그] 오늘 이미 업로드했는가? {}", hasUploadedToday);
 
 		if (hasUploadedToday) {
 			return CheckSelfieUploadableResponse.notUploadable("ALREADY_UPLOADED_TODAY");

--- a/src/main/java/com/sixpack/dorundorun/feature/run/api/RunController.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/run/api/RunController.java
@@ -15,6 +15,8 @@ import org.springframework.web.multipart.MultipartFile;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sixpack.dorundorun.feature.run.application.CompleteRunSessionService;
+import com.sixpack.dorundorun.global.exception.CustomException;
+import com.sixpack.dorundorun.global.exception.GlobalErrorCode;
 import com.sixpack.dorundorun.feature.run.application.CreateRunSessionService;
 import com.sixpack.dorundorun.feature.run.application.FindAllRunSessionsService;
 import com.sixpack.dorundorun.feature.run.application.FindRunSessionDetailService;
@@ -91,7 +93,7 @@ public class RunController implements RunApi {
 
 			return DorunResponse.success("러닝 세션이 성공적으로 완료되었습니다.", response);
 		} catch (JsonProcessingException e) {
-			throw new IllegalArgumentException("잘못된 JSON 형식입니다.", e);
+			throw new CustomException(GlobalErrorCode.INVALID_INPUT, "잘못된 JSON 형식입니다.");
 		}
 	}
 

--- a/src/main/java/com/sixpack/dorundorun/global/utils/KoreaTimeHandler.java
+++ b/src/main/java/com/sixpack/dorundorun/global/utils/KoreaTimeHandler.java
@@ -80,7 +80,7 @@ public class KoreaTimeHandler {
 			return null;
 		}
 		return date.atStartOfDay(KOREA_ZONE)
-			.withZoneSameInstant(ZoneId.of("UTC"))
+			.withZoneSameInstant(UTC_ZONE)
 			.toLocalDateTime();
 	}
 
@@ -96,7 +96,7 @@ public class KoreaTimeHandler {
 		}
 		return date.atTime(LocalTime.MAX)
 			.atZone(KOREA_ZONE)
-			.withZoneSameInstant(ZoneId.of("UTC"))
+			.withZoneSameInstant(UTC_ZONE)
 			.toLocalDateTime();
 	}
 

--- a/src/main/java/com/sixpack/dorundorun/global/utils/KoreaTimeHandler.java
+++ b/src/main/java/com/sixpack/dorundorun/global/utils/KoreaTimeHandler.java
@@ -1,0 +1,147 @@
+package com.sixpack.dorundorun.global.utils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 한국 시간대(Asia/Seoul) 기준으로 날짜/시간을 처리하는 핸들러
+ * DB에 저장된 시간을 한국 시간대로 변환하거나, 한국 시간대 기준으로 현재 시간을 제공합니다.
+ */
+@Slf4j
+@Component
+public class KoreaTimeHandler {
+
+	private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+	private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+
+	/**
+	 * 한국 시간대 기준 현재 날짜를 반환합니다.
+	 *
+	 * @return 한국 시간대 기준 현재 날짜
+	 */
+	public LocalDate now() {
+		return LocalDate.now(KOREA_ZONE);
+	}
+
+	/**
+	 * 한국 시간대 기준 현재 날짜/시간을 반환합니다.
+	 *
+	 * @return 한국 시간대 기준 현재 날짜/시간
+	 */
+	public LocalDateTime nowDateTime() {
+		return LocalDateTime.now(KOREA_ZONE);
+	}
+
+	/**
+	 * UTC 시간을 한국 시간대로 변환합니다.
+	 *
+	 * @param utcDateTime UTC 시간
+	 * @return 한국 시간대로 변환된 날짜/시간
+	 */
+	public LocalDateTime toKoreaTime(LocalDateTime utcDateTime) {
+		if (utcDateTime == null) {
+			return null;
+		}
+		LocalDateTime koreaTime = utcDateTime
+			.atZone(UTC_ZONE)
+			.withZoneSameInstant(KOREA_ZONE)
+			.toLocalDateTime();
+		log.debug("[KoreaTimeHandler] UTC {} -> 한국시간 {}", utcDateTime, koreaTime);
+		return koreaTime;
+	}
+
+	/**
+	 * UTC 시간을 한국 시간대의 날짜로 변환합니다.
+	 *
+	 * @param utcDateTime UTC 시간
+	 * @return 한국 시간대로 변환된 날짜
+	 */
+	public LocalDate toKoreaDate(LocalDateTime utcDateTime) {
+		if (utcDateTime == null) {
+			return null;
+		}
+		return toKoreaTime(utcDateTime).toLocalDate();
+	}
+
+	/**
+	 * 한국 시간대 기준 특정 날짜의 시작 시간(00:00:00)을 UTC로 반환합니다.
+	 *
+	 * @param date 한국 시간대 기준 날짜
+	 * @return UTC 시간으로 변환된 해당 날짜의 시작 시간
+	 */
+	public LocalDateTime startOfDayInUtc(LocalDate date) {
+		if (date == null) {
+			return null;
+		}
+		return date.atStartOfDay(KOREA_ZONE)
+			.withZoneSameInstant(ZoneId.of("UTC"))
+			.toLocalDateTime();
+	}
+
+	/**
+	 * 한국 시간대 기준 특정 날짜의 종료 시간(23:59:59.999999999)을 UTC로 반환합니다.
+	 *
+	 * @param date 한국 시간대 기준 날짜
+	 * @return UTC 시간으로 변환된 해당 날짜의 종료 시간
+	 */
+	public LocalDateTime endOfDayInUtc(LocalDate date) {
+		if (date == null) {
+			return null;
+		}
+		return date.atTime(LocalTime.MAX)
+			.atZone(KOREA_ZONE)
+			.withZoneSameInstant(ZoneId.of("UTC"))
+			.toLocalDateTime();
+	}
+
+	/**
+	 * 두 시간이 한국 시간대 기준으로 같은 날인지 확인합니다.
+	 *
+	 * @param utcDateTime1 비교할 첫 번째 UTC 시간
+	 * @param utcDateTime2 비교할 두 번째 UTC 시간
+	 * @return 같은 날이면 true, 아니면 false
+	 */
+	public boolean isSameDayInKorea(LocalDateTime utcDateTime1, LocalDateTime utcDateTime2) {
+		if (utcDateTime1 == null || utcDateTime2 == null) {
+			return false;
+		}
+		return toKoreaDate(utcDateTime1).equals(toKoreaDate(utcDateTime2));
+	}
+
+	/**
+	 * UTC 시간이 한국 시간대 기준으로 오늘인지 확인합니다.
+	 *
+	 * @param utcDateTime 확인할 UTC 시간
+	 * @return 오늘이면 true, 아니면 false
+	 */
+	public boolean isTodayInKorea(LocalDateTime utcDateTime) {
+		if (utcDateTime == null) {
+			return false;
+		}
+		return toKoreaDate(utcDateTime).equals(now());
+	}
+
+	/**
+	 * 한국 시간대 기준 오늘의 시작 시간(00:00:00)을 UTC로 반환합니다.
+	 *
+	 * @return UTC 시간으로 변환된 오늘의 시작 시간
+	 */
+	public LocalDateTime todayStartInUtc() {
+		return startOfDayInUtc(now());
+	}
+
+	/**
+	 * 한국 시간대 기준 오늘의 종료 시간(23:59:59.999999999)을 UTC로 반환합니다.
+	 *
+	 * @return UTC 시간으로 변환된 오늘의 종료 시간
+	 */
+	public LocalDateTime todayEndInUtc() {
+		return endOfDayInUtc(now());
+	}
+}

--- a/src/main/java/com/sixpack/dorundorun/infra/sms/solapi/SolapiProvider.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/sms/solapi/SolapiProvider.java
@@ -33,13 +33,10 @@ public class SolapiProvider implements SmsProvider {
 
 	@PostConstruct
 	public void init() {
-		// Solapi SDK 초기화 (API 키, API Secret 키 설정)
 		this.messageService = SolapiClient.INSTANCE.createInstance(
 			solapiProperties.getApiKey(),
 			solapiProperties.getApiSecret()
 		);
-		log.info("[Solapi] Message service initialized with API key: {}***",
-			solapiProperties.getApiKey().substring(0, Math.min(8, solapiProperties.getApiKey().length())));
 	}
 
 	@Override


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
  - closed #103

  ### 문제 상황
  1. **시간대 불일치 문제**: 서버는 UTC로 저장하지만 클라이언트는 한국 시간 기준으로 판단하여, 셀피 업로드 가능 여부 확인 시 시간대 차이로 인한 오류 발생
  2. **부적절한 에러 응답**: JSON 파싱 실패 시 `IllegalArgumentException`을 던져 500 Internal Server Error로 응답되는 문제
  3. **레이어 책임 분리 미흡**: SignUpService에서 JSON 파싱을 처리하여 서비스 레이어가 HTTP 요청 처리 책임까지 담당

  ## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

  ### 1. 한국 시간대 처리 모듈화
  - `KoreaTimeHandler` 클래스 신규 생성 (`/global/utils/KoreaTimeHandler.java`)
    - UTC ↔ 한국시간 변환 기능 제공
    - `isTodayInKorea()`: UTC 시간이 한국 시간 기준으로 오늘인지 확인
    - `todayStartInUtc()`, `todayEndInUtc()`: 한국 시간 기준 오늘 범위를 UTC로 변환

  ### 2. CheckSelfieUploadableService 개선
  - `KoreaTimeHandler`를 활용하여 시간 판단 로직 개선
  - DB에 저장된 시간을 한국 시간 기준으로 비교

  ### 3. JSON 파싱 에러 응답 개선
  - `IllegalArgumentException` → `CustomException(GlobalErrorCode.INVALID_INPUT)` 변경
  - 잘못된 JSON 형식 요청 시 500 에러 대신 **400 Bad Request** 응답
  - 영향받는 API:
    - `POST /api/runs/sessions/{sessionId}/complete` (러닝 완료)
    - `POST /api/selfie` (셀피 생성)
    - `PUT /api/selfie/feeds/{feedId}` (셀피 수정)
    - `POST /api/auth/signup` (회원가입)

  ## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

  ### 레이어 책임 분리 개선
  - **SignUpService의 JSON 파싱 로직을 AuthController로 이동**
    - Before: `signUpService.signUp(String dataJson, MultipartFile)`
    - After: `signUpService.signUp(SignUpRequest request, MultipartFile)`

  ## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

  ## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

  ### 📌 PR 진행 시 이러한 점들을 참고해 주세요
  * Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
  * Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
  * Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
  * Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
      * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
      * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
      * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)

  ---
  ## 📝 Assignee를 위한 CheckList

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 한국 시간대(KST) 기반의 중앙 집중형 날짜/시간 유틸 추가(오늘/시작/종료 계산 및 변환)

* **버그 수정**
  * 회원가입 입력 JSON 파싱 실패에 대한 검증 및 일관된 에러 응답 개선
  * 셀피 업로드 및 러닝 완료 처리의 입력 파싱 오류 경로에 대한 일관된 오류 반환 적용
  * 한국 시간 기준으로 업로드 가능성 검사 로직 개선

* **기타**
  * 초기화 시 민감 정보 노출 로그 제거 (초기화 동작은 유지)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->