### PR TITLE
fix: 알림 목록에 탈퇴한 사용자가 있을 시에 알수없음 처리

### DIFF
--- a/src/main/java/com/sixpack/dorundorun/feature/notification/application/NotificationsService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/application/NotificationsService.java
@@ -58,11 +58,6 @@ public class NotificationsService {
 				if (feed != null) {
 					if (feed.getUser() != null) {
 						profileImage = getProfileImageFromUser(feed.getUser());
-					} else {
-						// 업로더가 탈퇴한 경우 uploaderName을 null로 설정
-						if (notification.getData().getAdditionalData() != null) {
-							notification.getData().getAdditionalData().put("uploaderName", null);
-						}
 					}
 					if (feed.getSelfieImage() != null) {
 						selfieImage = s3Service.getImageUrl(feed.getSelfieImage());

--- a/src/main/java/com/sixpack/dorundorun/feature/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/dto/response/NotificationResponse.java
@@ -96,7 +96,7 @@ public class NotificationResponse {
 			.title(notification.getData().getTitle())
 			.message(message)
 			.sender(sender)
-			.profileImage("/api/images/defaultProfileImage.jpg")
+			.profileImage(DEFAULT_PROFILE_IMAGE)
 			.type(notification.getType())
 			.isRead(notification.getIsRead())
 			.readAt(notification.getReadAt())

--- a/src/main/java/com/sixpack/dorundorun/feature/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/dto/response/NotificationResponse.java
@@ -31,6 +31,8 @@ import lombok.Getter;
 		""")
 public class NotificationResponse {
 
+	private static final String DEFAULT_PROFILE_IMAGE = "/api/images/defaultProfileImage.jpg";
+
 	@Schema(description = "알림 ID", example = "1")
 	private Long id;
 
@@ -145,6 +147,12 @@ public class NotificationResponse {
 		String message = notification.getData().getMessage();
 		String sender = getSenderName(notification);
 
+		// 발신자가 탈퇴한 경우 "알 수 없음" 표시
+		if (sender == null && isNotificationRequiresSender(notification)) {
+			sender = "알 수 없음";
+			profileImage = DEFAULT_PROFILE_IMAGE;
+		}
+
 		// 응답에서는 메시지에서 발신자 이름과 "님" 제거
 		if (sender != null && message != null) {
 			message = message.replace(sender + "님", "");
@@ -164,5 +172,11 @@ public class NotificationResponse {
 			.selfieImage(selfieImage)
 			.createdAt(notification.getCreatedAt())
 			.build();
+	}
+
+	private static boolean isNotificationRequiresSender(Notification notification) {
+		return notification.getType() == NotificationType.CHEER_FRIEND
+			|| notification.getType() == NotificationType.FEED_REACTION
+			|| notification.getType() == NotificationType.FEED_UPLOADED;
 	}
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #114 
>관련 이슈 번호를 할당해주세요
>
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요.
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

*

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
* 탈퇴한 사용자가 있을시에 알수없음, defaultProfileImage가 뜨도록 처리했습니다!

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 알림 생성 시 발신자 정보가 없는 경우 '알 수 없음'으로 표시하도록 개선
  * 피드 발송 처리에서 사용자 정보 누락 시 발생하던 예외 방지용 널 체크 추가
  * 프로필 이미지 로드 실패 시 새 기본 이미지 상수로 대체하여 일관성 확보
  * 사용자 조회 및 파싱 오류 처리 강화로 알림 조회 안정성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->