### PR TITLE
feat: 푸시 알림 중복 방지 및 Redis Stream 안정성 개선

### DIFF
--- a/src/main/java/com/sixpack/dorundorun/feature/feed/event/handler/FeedReminderEventHandler.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/event/handler/FeedReminderEventHandler.java
@@ -109,6 +109,8 @@ public class FeedReminderEventHandler
 				eventId, event.userId(), event.runSessionId(), scheduledTime);
 
 		} catch (Exception e) {
+			// 실패 시 중복 방지 키 해제하여 재시도 가능하게 함
+			redisTemplate.delete(scheduleCheckKey);
 			log.error("Failed to schedule feed reminder event: userId={}, runSessionId={}",
 				event.userId(), event.runSessionId(), e);
 			throw e;

--- a/src/main/java/com/sixpack/dorundorun/feature/feed/event/handler/FeedReminderEventHandler.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/feed/event/handler/FeedReminderEventHandler.java
@@ -1,5 +1,6 @@
 package com.sixpack.dorundorun.feature.feed.event.handler;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.UUID;
@@ -47,6 +48,16 @@ public class FeedReminderEventHandler
 	protected void onMessage(FeedReminderRequestedEvent event) throws Exception {
 		log.info("Processing feed reminder event: userId={}, runSessionId={}",
 			event.userId(), event.runSessionId());
+
+		// 중복 스케줄 방지: 이미 스케줄된 알림인지 Redis에서 확인
+		String scheduleCheckKey = "schedule:check:FEED_REMINDER:" + event.userId() + ":" + event.runSessionId();
+		Boolean isNew = redisTemplate.opsForValue().setIfAbsent(scheduleCheckKey, "1", Duration.ofHours(25));
+
+		if (!Boolean.TRUE.equals(isNew)) {
+			log.info("Feed reminder already scheduled, skipping: userId={}, runSessionId={}",
+				event.userId(), event.runSessionId());
+			return;
+		}
 
 		try {
 			// 예약 시간 계산: 지금 + 23시간 (러닝 완료 후 23시간)

--- a/src/main/java/com/sixpack/dorundorun/feature/notification/application/PushNotificationDeduplicationService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/application/PushNotificationDeduplicationService.java
@@ -1,0 +1,89 @@
+package com.sixpack.dorundorun.feature.notification.application;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.sixpack.dorundorun.feature.notification.event.PushNotificationRequestedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushNotificationDeduplicationService {
+
+	private static final String DEDUP_KEY_PREFIX = "push:dedup:";
+
+	private static final Map<String, Duration> TTL_BY_TYPE = Map.of(
+		"CHEER_FRIEND", Duration.ofHours(1),
+		"FEED_UPLOADED", Duration.ofHours(24),
+		"FEED_REACTION", Duration.ofHours(1),
+		"FEED_REMINDER", Duration.ofHours(25),
+		"RUNNING_PROGRESS_REMINDER", Duration.ofDays(8),
+		"NEW_USER_RUNNING_REMINDER", Duration.ofDays(8),
+		"NEW_USER_FRIEND_REMINDER", Duration.ofDays(4)
+	);
+
+	private static final Duration DEFAULT_TTL = Duration.ofHours(24);
+
+	private final StringRedisTemplate redisTemplate;
+
+	/**
+	 * 중복 체크 및 락 획득 시도
+	 * @return true면 처리 가능 (신규), false면 중복
+	 */
+	public boolean tryAcquireLock(PushNotificationRequestedEvent event) {
+		String dedupKey = generateDedupKey(event);
+		Duration ttl = getTtlForType(event.notificationType());
+
+		Boolean acquired = redisTemplate.opsForValue().setIfAbsent(dedupKey, "1", ttl);
+
+		if (Boolean.TRUE.equals(acquired)) {
+			log.debug("Dedup lock acquired: key={}", dedupKey);
+			return true;
+		} else {
+			log.info("Duplicate notification detected, skipping: key={}", dedupKey);
+			return false;
+		}
+	}
+
+	/**
+	 * 이벤트로부터 중복 방지 키 생성
+	 */
+	public String generateDedupKey(PushNotificationRequestedEvent event) {
+		StringBuilder keyBuilder = new StringBuilder(DEDUP_KEY_PREFIX)
+			.append(event.notificationType())
+			.append(":")
+			.append(event.recipientUserId());
+
+		if (event.relatedId() != null && !event.relatedId().isEmpty()) {
+			keyBuilder.append(":").append(event.relatedId());
+		}
+
+		// CHEER_FRIEND의 경우 응원한 사용자 ID도 추가 (동일인이 같은 사람에게 연속 응원 방지)
+		if ("CHEER_FRIEND".equals(event.notificationType()) && event.metadata() != null) {
+			Object cheererId = event.metadata().get("cheererId");
+			if (cheererId != null) {
+				keyBuilder.append(":").append(cheererId);
+			}
+		}
+
+		// FEED_REACTION의 경우 리액션한 사용자 ID도 추가
+		if ("FEED_REACTION".equals(event.notificationType()) && event.metadata() != null) {
+			Object reactorId = event.metadata().get("reactorId");
+			if (reactorId != null) {
+				keyBuilder.append(":").append(reactorId);
+			}
+		}
+
+		return keyBuilder.toString();
+	}
+
+	private Duration getTtlForType(String notificationType) {
+		return TTL_BY_TYPE.getOrDefault(notificationType, DEFAULT_TTL);
+	}
+}

--- a/src/main/java/com/sixpack/dorundorun/feature/notification/application/PushNotificationDeduplicationService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/application/PushNotificationDeduplicationService.java
@@ -40,14 +40,26 @@ public class PushNotificationDeduplicationService {
 		String dedupKey = generateDedupKey(event);
 		Duration ttl = getTtlForType(event.notificationType());
 
-		Boolean acquired = redisTemplate.opsForValue().setIfAbsent(dedupKey, "1", ttl);
+		try {
+			Boolean acquired = redisTemplate.opsForValue().setIfAbsent(dedupKey, "1", ttl);
 
-		if (Boolean.TRUE.equals(acquired)) {
-			log.debug("Dedup lock acquired: key={}", dedupKey);
+			if (acquired == null) {
+				// Redis 오류로 null 반환 시 fail-open (알림 발송 허용)
+				log.warn("Redis returned null for dedup check, proceeding with notification: key={}", dedupKey);
+				return true;
+			}
+
+			if (acquired) {
+				log.debug("Dedup lock acquired: key={}", dedupKey);
+				return true;
+			} else {
+				log.info("Duplicate notification detected, skipping: key={}", dedupKey);
+				return false;
+			}
+		} catch (Exception e) {
+			// Redis 연결 오류 시 fail-open (알림 발송 허용)
+			log.warn("Redis error during dedup check, proceeding with notification: key={}", dedupKey, e);
 			return true;
-		} else {
-			log.info("Duplicate notification detected, skipping: key={}", dedupKey);
-			return false;
 		}
 	}
 
@@ -55,6 +67,11 @@ public class PushNotificationDeduplicationService {
 	 * 이벤트로부터 중복 방지 키 생성
 	 */
 	public String generateDedupKey(PushNotificationRequestedEvent event) {
+		// idempotencyKey가 명시적으로 설정된 경우 이를 우선 사용
+		if (event.idempotencyKey() != null && !event.idempotencyKey().isEmpty()) {
+			return DEDUP_KEY_PREFIX + event.idempotencyKey();
+		}
+
 		StringBuilder keyBuilder = new StringBuilder(DEDUP_KEY_PREFIX)
 			.append(event.notificationType())
 			.append(":")

--- a/src/main/java/com/sixpack/dorundorun/feature/notification/application/SaveNotificationService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/application/SaveNotificationService.java
@@ -9,9 +9,9 @@ import com.sixpack.dorundorun.feature.notification.dao.NotificationJpaRepository
 import com.sixpack.dorundorun.feature.notification.domain.Notification;
 import com.sixpack.dorundorun.feature.notification.domain.NotificationData;
 import com.sixpack.dorundorun.feature.notification.domain.NotificationType;
+import com.sixpack.dorundorun.feature.notification.event.PushNotificationRequestedEvent;
 import com.sixpack.dorundorun.feature.user.application.FindUserByIdService;
 import com.sixpack.dorundorun.feature.user.domain.User;
-import com.sixpack.dorundorun.feature.notification.event.PushNotificationRequestedEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +46,6 @@ public class SaveNotificationService {
 			.additionalData(additionalData)
 			.build();
 
-		// 알림 타입을 문자열에서 NotificationType enum으로 변환
 		NotificationType notificationType = convertToNotificationType(event.notificationType());
 
 		Notification notification = Notification.builder()

--- a/src/main/java/com/sixpack/dorundorun/feature/notification/event/PushNotificationRequestedEvent.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/event/PushNotificationRequestedEvent.java
@@ -12,7 +12,8 @@ public record PushNotificationRequestedEvent(
 	Long recipientUserId,
 	String notificationType,
 	String relatedId,
-	Map<String, Object> metadata
+	Map<String, Object> metadata,
+	String idempotencyKey
 ) implements RedisStreamEvent {
 
 	public static final String TYPE = RedisStreamEventType.PUSH_NOTIFICATION_REQUESTED;

--- a/src/main/java/com/sixpack/dorundorun/feature/notification/event/listener/PushNotificationEventListener.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/event/listener/PushNotificationEventListener.java
@@ -2,10 +2,11 @@ package com.sixpack.dorundorun.feature.notification.event.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sixpack.dorundorun.feature.notification.application.PushNotificationContentDeterminer;
+import com.sixpack.dorundorun.feature.notification.application.PushNotificationDeduplicationService;
 import com.sixpack.dorundorun.feature.notification.application.SaveNotificationService;
 import com.sixpack.dorundorun.feature.notification.application.SendPushNotificationService;
-import com.sixpack.dorundorun.infra.redis.stream.annotation.RedisStreamEventListener;
 import com.sixpack.dorundorun.feature.notification.event.PushNotificationRequestedEvent;
+import com.sixpack.dorundorun.infra.redis.stream.annotation.RedisStreamEventListener;
 import com.sixpack.dorundorun.infra.redis.stream.handler.AbstractRedisStreamEventHandler;
 
 import lombok.extern.slf4j.Slf4j;
@@ -14,17 +15,20 @@ import lombok.extern.slf4j.Slf4j;
 @RedisStreamEventListener
 public class PushNotificationEventListener extends AbstractRedisStreamEventHandler<PushNotificationRequestedEvent> {
 
+	private final PushNotificationDeduplicationService deduplicationService;
 	private final SaveNotificationService saveNotificationService;
 	private final SendPushNotificationService sendPushNotificationService;
 	private final PushNotificationContentDeterminer contentDeterminer;
 
 	public PushNotificationEventListener(
 		ObjectMapper objectMapper,
+		PushNotificationDeduplicationService deduplicationService,
 		SaveNotificationService saveNotificationService,
 		SendPushNotificationService sendPushNotificationService,
 		PushNotificationContentDeterminer contentDeterminer
 	) {
 		super(objectMapper);
+		this.deduplicationService = deduplicationService;
 		this.saveNotificationService = saveNotificationService;
 		this.sendPushNotificationService = sendPushNotificationService;
 		this.contentDeterminer = contentDeterminer;
@@ -44,6 +48,13 @@ public class PushNotificationEventListener extends AbstractRedisStreamEventHandl
 	protected void onMessage(PushNotificationRequestedEvent event) throws Exception {
 		log.info("Processing push notification event: recipientId={}, type={}",
 			event.recipientUserId(), event.notificationType());
+
+		// Redis SETNX 중복 체크 - 푸시 보내기 "직전"에
+		if (!deduplicationService.tryAcquireLock(event)) {
+			log.info("Duplicate notification skipped: recipientId={}, type={}",
+				event.recipientUserId(), event.notificationType());
+			return; // ACK 처리됨 (onMessage가 정상 종료되면 ACK)
+		}
 
 		try {
 			// 알림 콘텐츠 결정

--- a/src/main/java/com/sixpack/dorundorun/feature/notification/event/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/event/scheduler/NotificationScheduler.java
@@ -167,6 +167,7 @@ public class NotificationScheduler {
 						.notificationType(scheduledData.getNotificationType())
 						.relatedId(null)
 						.metadata(new HashMap<>())
+						.idempotencyKey(eventId)  // 스케줄러의 eventId를 idempotencyKey로 사용
 						.build();
 					redisStreamPublisher.publishAfterCommit(pushEvent);
 

--- a/src/main/java/com/sixpack/dorundorun/feature/run/event/handler/RunningProgressReminderEventHandler.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/run/event/handler/RunningProgressReminderEventHandler.java
@@ -1,5 +1,6 @@
 package com.sixpack.dorundorun.feature.run.event.handler;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.UUID;
@@ -47,6 +48,16 @@ public class RunningProgressReminderEventHandler
 	protected void onMessage(RunningProgressReminderRequestedEvent event) throws Exception {
 		log.info("Processing running progress reminder event: userId={}, runSessionId={}",
 			event.userId(), event.runSessionId());
+
+		// 중복 스케줄 방지: 이미 스케줄된 알림인지 Redis에서 확인
+		String scheduleCheckKey = "schedule:check:RUNNING_PROGRESS:" + event.userId() + ":" + event.runSessionId();
+		Boolean isNew = redisTemplate.opsForValue().setIfAbsent(scheduleCheckKey, "1", Duration.ofDays(8));
+
+		if (!Boolean.TRUE.equals(isNew)) {
+			log.info("Running progress reminder already scheduled, skipping: userId={}, runSessionId={}",
+				event.userId(), event.runSessionId());
+			return;
+		}
 
 		try {
 			// 예약 시간 계산: 지금 + 7일 (마지막 러닝 완료 후 7일)

--- a/src/main/java/com/sixpack/dorundorun/feature/run/event/handler/RunningProgressReminderEventHandler.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/run/event/handler/RunningProgressReminderEventHandler.java
@@ -107,6 +107,8 @@ public class RunningProgressReminderEventHandler
 				eventId, event.userId(), event.runSessionId(), scheduledTime);
 
 		} catch (Exception e) {
+			// 실패 시 중복 방지 키 해제하여 재시도 가능하게 함
+			redisTemplate.delete(scheduleCheckKey);
 			log.error("Failed to schedule running progress reminder event: userId={}, runSessionId={}",
 				event.userId(), event.runSessionId(), e);
 			throw e;

--- a/src/main/java/com/sixpack/dorundorun/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/sixpack/dorundorun/global/exception/GlobalErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum GlobalErrorCode implements ErrorCode {
 
 	INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다"),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
 
 	private final HttpStatus status;

--- a/src/main/java/com/sixpack/dorundorun/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sixpack/dorundorun/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.sixpack.dorundorun.global.response.DorunResponse;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,6 +24,15 @@ public class GlobalExceptionHandler {
 		return ResponseEntity
 			.status(e.getErrorCode().getStatus())
 			.body(DorunResponse.error(e.getErrorCode(), e.getMessage()));
+	}
+
+	@ExceptionHandler(ExpiredJwtException.class)
+	public ResponseEntity<DorunResponse<Void>> handleExpiredJwtException(ExpiredJwtException e,
+		HttpServletRequest req) {
+		log.warn("{} {} - JWT token expired", req.getMethod(), req.getRequestURI());
+		return ResponseEntity
+			.status(HttpStatus.UNAUTHORIZED)
+			.body(DorunResponse.error(GlobalErrorCode.UNAUTHORIZED, "토큰이 만료되었습니다."));
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmServiceImpl.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmServiceImpl.java
@@ -121,8 +121,13 @@ public class FcmServiceImpl implements FcmService {
 		builder.setNotification(notification);
 
 		if (message.data() != null) {
-			builder.putData("notificationType", message.data().notificationType());
-			builder.putData("relatedId", message.data().relatedId());
+			if (message.data().notificationType() != null) {
+				builder.putData("notificationType", message.data().notificationType());
+			}
+
+			if (message.data().relatedId() != null) {
+				builder.putData("relatedId", message.data().relatedId());
+			}
 
 			if (message.data().metadata() != null && !message.data().metadata().isEmpty()) {
 				builder.putAllData(message.data().metadata());
@@ -154,8 +159,13 @@ public class FcmServiceImpl implements FcmService {
 		builder.setNotification(notification);
 
 		if (message.data() != null) {
-			builder.putData("notificationType", message.data().notificationType());
-			builder.putData("relatedId", message.data().relatedId());
+			if (message.data().notificationType() != null) {
+				builder.putData("notificationType", message.data().notificationType());
+			}
+
+			if (message.data().relatedId() != null) {
+				builder.putData("relatedId", message.data().relatedId());
+			}
 
 			if (message.data().metadata() != null && !message.data().metadata().isEmpty()) {
 				builder.putAllData(message.data().metadata());

--- a/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/DeadLetterQueueService.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/DeadLetterQueueService.java
@@ -1,0 +1,72 @@
+package com.sixpack.dorundorun.infra.redis.stream.recovery;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sixpack.dorundorun.global.config.redis.stream.RedisStreamProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeadLetterQueueService {
+
+	private static final String DLQ_KEY_SUFFIX = ":dlq";
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisStreamProperties properties;
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * 실패한 메시지를 DLQ로 이동
+	 */
+	public void moveToDeadLetterQueue(
+		String recordId,
+		String messageJson,
+		String errorMessage,
+		long retryCount
+	) {
+		try {
+			String dlqKey = properties.key() + DLQ_KEY_SUFFIX;
+
+			Map<String, Object> dlqEntry = new HashMap<>();
+			dlqEntry.put("originalRecordId", recordId);
+			dlqEntry.put("originalMessage", messageJson);
+			dlqEntry.put("errorMessage", errorMessage);
+			dlqEntry.put("retryCount", retryCount);
+			dlqEntry.put("movedAt", LocalDateTime.now().toString());
+			dlqEntry.put("originalStream", properties.key());
+
+			String dlqEntryJson = objectMapper.writeValueAsString(dlqEntry);
+
+			redisTemplate.opsForStream().add(
+				StreamRecords.newRecord()
+					.ofObject(dlqEntryJson)
+					.withStreamKey(dlqKey)
+			);
+
+			log.warn("Message moved to DLQ: recordId={}, retryCount={}, error={}",
+				recordId, retryCount, errorMessage);
+
+		} catch (Exception e) {
+			log.error("Failed to move message to DLQ: recordId={}", recordId, e);
+		}
+	}
+
+	/**
+	 * DLQ에 있는 메시지 수 반환
+	 */
+	public long getDlqSize() {
+		String dlqKey = properties.key() + DLQ_KEY_SUFFIX;
+		Long size = redisTemplate.opsForStream().size(dlqKey);
+		return size != null ? size : 0;
+	}
+}

--- a/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/DeadLetterQueueService.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/DeadLetterQueueService.java
@@ -27,8 +27,9 @@ public class DeadLetterQueueService {
 
 	/**
 	 * 실패한 메시지를 DLQ로 이동
+	 * @return true면 DLQ 이동 성공, false면 실패
 	 */
-	public void moveToDeadLetterQueue(
+	public boolean moveToDeadLetterQueue(
 		String recordId,
 		String messageJson,
 		String errorMessage,
@@ -56,8 +57,10 @@ public class DeadLetterQueueService {
 			log.warn("Message moved to DLQ: recordId={}, retryCount={}, error={}",
 				recordId, retryCount, errorMessage);
 
+			return true;
 		} catch (Exception e) {
 			log.error("Failed to move message to DLQ: recordId={}", recordId, e);
+			return false;
 		}
 	}
 

--- a/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/RedisStreamRecovery.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/RedisStreamRecovery.java
@@ -24,10 +24,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RedisStreamRecovery {
 
+	private static final int MAX_RETRY_COUNT = 5;
+	private static final long[] BACKOFF_DELAYS_MS = {1000, 2000, 5000, 10000, 30000};
+
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final RedisStreamProperties properties;
 	private final RedisStreamMessageProcessor processor;
 	private final RedisStreamMessageMapper mapper;
+	private final DeadLetterQueueService deadLetterQueueService;
 
 	public void reprocessPending(long minIdleMs, long count) {
 		PendingMessagesSummary summary = redisTemplate.opsForStream()
@@ -50,7 +54,17 @@ public class RedisStreamRecovery {
 		);
 
 		for (PendingMessage pm : pending) {
-			if (pm.getElapsedTimeSinceLastDelivery().toMillis() < minIdleMs) {
+			long deliveryCount = pm.getTotalDeliveryCount();
+
+			// 최대 재시도 횟수 초과 시 DLQ로 이동
+			if (deliveryCount > MAX_RETRY_COUNT) {
+				handleMaxRetryExceeded(pm);
+				continue;
+			}
+
+			// Exponential backoff 적용
+			long requiredIdleMs = getBackoffDelay(deliveryCount);
+			if (pm.getElapsedTimeSinceLastDelivery().toMillis() < requiredIdleMs) {
 				continue;
 			}
 
@@ -58,7 +72,7 @@ public class RedisStreamRecovery {
 				properties.key(),
 				properties.group(),
 				properties.consumerName(),
-				Duration.ofMillis(minIdleMs),
+				Duration.ofMillis(requiredIdleMs),
 				pm.getId()
 			);
 
@@ -66,9 +80,54 @@ public class RedisStreamRecovery {
 				try {
 					reprocessRecord(record);
 				} catch (Exception e) {
-					log.error("Reprocess failed for message: {}", record.getId(), e);
+					log.error("Reprocess failed for message: id={}, deliveryCount={}", record.getId(), deliveryCount, e);
 				}
 			}
+		}
+	}
+
+	private long getBackoffDelay(long deliveryCount) {
+		int index = Math.min((int) deliveryCount - 1, BACKOFF_DELAYS_MS.length - 1);
+		return index >= 0 ? BACKOFF_DELAYS_MS[index] : BACKOFF_DELAYS_MS[0];
+	}
+
+	private void handleMaxRetryExceeded(PendingMessage pm) {
+		try {
+			// 메시지 내용 조회
+			List<MapRecord<String, Object, Object>> records = redisTemplate.opsForStream().range(
+				properties.key(),
+				Range.just(pm.getId().getValue())
+			);
+
+			String messageJson = "";
+			if (records != null && !records.isEmpty()) {
+				MapRecord<String, Object, Object> record = records.get(0);
+				Object raw = record.getValue().get("value");
+				if (raw == null) {
+					raw = record.getValue().get("payload");
+				}
+				messageJson = raw != null ? String.valueOf(raw) : "";
+			}
+
+			// DLQ로 이동
+			deadLetterQueueService.moveToDeadLetterQueue(
+				pm.getId().getValue(),
+				messageJson,
+				"Max retry count exceeded: " + MAX_RETRY_COUNT,
+				pm.getTotalDeliveryCount()
+			);
+
+			// ACK 처리하여 PEL에서 제거
+			redisTemplate.opsForStream().acknowledge(
+				properties.key(),
+				properties.group(),
+				pm.getId()
+			);
+
+			log.warn("Message moved to DLQ after {} retries: id={}", MAX_RETRY_COUNT, pm.getId());
+
+		} catch (Exception e) {
+			log.error("Failed to handle max retry exceeded: id={}", pm.getId(), e);
 		}
 	}
 

--- a/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/RedisStreamRecovery.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/RedisStreamRecovery.java
@@ -110,21 +110,24 @@ public class RedisStreamRecovery {
 			}
 
 			// DLQ로 이동
-			deadLetterQueueService.moveToDeadLetterQueue(
+			boolean movedToDlq = deadLetterQueueService.moveToDeadLetterQueue(
 				pm.getId().getValue(),
 				messageJson,
 				"Max retry count exceeded: " + MAX_RETRY_COUNT,
 				pm.getTotalDeliveryCount()
 			);
 
-			// ACK 처리하여 PEL에서 제거
-			redisTemplate.opsForStream().acknowledge(
-				properties.key(),
-				properties.group(),
-				pm.getId()
-			);
-
-			log.warn("Message moved to DLQ after {} retries: id={}", MAX_RETRY_COUNT, pm.getId());
+			// DLQ 이동 성공 시에만 ACK 처리하여 PEL에서 제거
+			if (movedToDlq) {
+				redisTemplate.opsForStream().acknowledge(
+					properties.key(),
+					properties.group(),
+					pm.getId()
+				);
+				log.warn("Message moved to DLQ after {} retries: id={}", MAX_RETRY_COUNT, pm.getId());
+			} else {
+				log.error("Failed to move message to DLQ, keeping in PEL for retry: id={}", pm.getId());
+			}
 
 		} catch (Exception e) {
 			log.error("Failed to handle max retry exceeded: id={}", pm.getId(), e);

--- a/src/test/java/com/sixpack/dorundorun/feature/notification/NotificationIntegrationTest.java
+++ b/src/test/java/com/sixpack/dorundorun/feature/notification/NotificationIntegrationTest.java
@@ -193,12 +193,12 @@ public class NotificationIntegrationTest extends ServiceTest {
 		// given
 		int count = 5;
 
-		// when
+		// when - 각 알림마다 다른 relatedId 사용 (중복 방지 키가 다르도록)
 		for (int i = 0; i < count; i++) {
 			PushNotificationRequestedEvent event = PushNotificationRequestedEvent.builder()
 				.recipientUserId(testUser.getId())
 				.notificationType("CHEER_FRIEND")
-				.relatedId(String.valueOf(testFriend.getId()))
+				.relatedId(String.valueOf(testFriend.getId() + i))  // 각기 다른 relatedId
 				.metadata(new HashMap<>())
 				.build();
 


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #123 
>관련 이슈 번호를 할당해주세요
>
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요.
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

* 푸시 알림이 중복 발송되는 문제와 Redis Stream 메시지 처리 실패 시 무한 재시도로 인한 리소스 낭비 문제를 해결했습니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
 1. **푸시 알림 중복 발송 방지**                                                                                                                                                                    
     - Redis SETNX 기반 중복 체크 로직 추가 (`PushNotificationDeduplicationService`)                                                                                                                 
     - 알림 타입별 TTL 차등 적용 (CHEER_FRIEND: 1시간, FEED_UPLOADED: 24시간 등)                                                                                                                     
                                                                                                                                                                                                     
  2. **Redis Stream Recovery 안정성 개선**                                                                                                                                                           
     - Exponential backoff 적용 (1초 → 2초 → 5초 → 10초 → 30초)                                                                                                                                      
     - 최대 5회 재시도 후 Dead Letter Queue로 이동                                                                                                                                                   
     - `DeadLetterQueueService` 추가                                                                                                                                                                 
                                                                                                                                                                                                     
  3. **스케줄 알림 중복 등록 방지**                                                                                                                                                                  
     - 피드 리마인더, 러닝 진행 리마인더 스케줄링 시 Redis로 중복 체크

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
*

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
  - 중복 방지 키 생성 로직이 적절한지 (`PushNotificationDeduplicationService.generateDedupKey`)                                                                                                      
  - 알림 타입별 TTL 값이 비즈니스 요구사항에 맞는지                                                                                                                                                  
  - Backoff 딜레이 값 (1초, 2초, 5초, 10초, 30초)이 적절한지 

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요
  - 동일 알림 연속 발송 시 중복 차단되는지 확인                                                                                                                                                      
  - Redis Stream 메시지 처리 실패 시 backoff 적용 및 DLQ 이동 확인                                                                                                                                   
  - 기존 알림 발송 기능 정상 동작 확인        

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [ ] To-Do Item


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 푸시 알림 중복 방지(아이디임포텐시/레디스 연동) 도입
  * 데드레터 큐(DLQ) 서비스 추가로 실패 메시지 보존 및 조회 가능

* **개선 사항**
  * 스케줄링 리마인더 중복 차단으로 중복 알림 감소
  * 재시도에 지수적 백오프 적용으로 처리 안정성 향상
  * FCM 페이로드에 null 값 미포함 처리

* **버그 수정**
  * 만료된 JWT에 대해 401 응답 및 표준화된 에러 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->