### PR TITLE
infra: Prometheus 커스텀 메트릭 추가 및 actuator 보안 강화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ WORKDIR /app
 
 # 앱 JAR 복사
 COPY --from=build /app/build/libs/*.jar /app/app.jar
-EXPOSE 8080
+EXPOSE 8080 9091
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmServiceImpl.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmServiceImpl.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MulticastMessage;
@@ -25,6 +27,7 @@ public class FcmServiceImpl implements FcmService {
 
 	private final FirebaseMessaging firebaseMessaging;
 	private final FirebaseProperties firebaseProperties;
+	private final MeterRegistry meterRegistry;
 
 	@Override
 	public String sendMessage(FcmMessage message) {
@@ -40,10 +43,12 @@ public class FcmServiceImpl implements FcmService {
 			Message fcmMessage = buildMessage(message);
 			String messageId = firebaseMessaging.send(fcmMessage);
 			log.info("Successfully sent FCM message (messageId: {})", messageId);
+			meterRegistry.counter("fcm.send", "result", "success").increment();
 			return messageId;
 
 		} catch (Exception e) {
 			log.error("Failed to send FCM message, error: {}", e.getMessage(), e);
+			meterRegistry.counter("fcm.send", "result", "failure").increment();
 			throw new CustomException(FcmErrorCode.FCM_SEND_FAILED);
 		}
 	}
@@ -91,10 +96,14 @@ public class FcmServiceImpl implements FcmService {
 				log.warn("Some tokens failed: {}", failedTokens);
 			}
 
+			meterRegistry.counter("fcm.send", "result", "success").increment(successMessageIds.size());
+			meterRegistry.counter("fcm.send", "result", "failure").increment(failedTokens.size());
+
 			return successMessageIds;
 
 		} catch (Exception e) {
 			log.error("Failed to send multicast FCM message, error: {}", e.getMessage(), e);
+			meterRegistry.counter("fcm.send", "result", "failure").increment(uniqueTokens.size());
 			throw new CustomException(FcmErrorCode.FCM_SEND_FAILED);
 		}
 	}

--- a/src/main/java/com/sixpack/dorundorun/infra/redis/stream/consumer/RedisStreamMessageProcessor.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/redis/stream/consumer/RedisStreamMessageProcessor.java
@@ -5,6 +5,7 @@ import com.sixpack.dorundorun.infra.redis.stream.dto.RedisStreamMessage;
 import com.sixpack.dorundorun.infra.redis.stream.handler.RedisStreamEventHandler;
 import com.sixpack.dorundorun.infra.redis.stream.handler.RedisStreamEventHandlerRegistry;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +20,7 @@ public class RedisStreamMessageProcessor {
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final RedisStreamEventHandlerRegistry handlerRegistry;
 	private final RedisStreamProperties properties;
+	private final MeterRegistry meterRegistry;
 
 	public void process(String recordId, RedisStreamMessage message) {
 		String type = message.getType();
@@ -34,8 +36,10 @@ public class RedisStreamMessageProcessor {
 			log.debug("Dispatch to handler: type={}, handler={}", type, handler.getClass().getSimpleName());
 			handler.handle(message);
 			this.ack(recordId);
+			meterRegistry.counter("notification.stream.processed", "type", type, "result", "success").increment();
 		} catch (Exception e) {
 			log.error("Handler failed: type={}, id={}", type, recordId, e);
+			meterRegistry.counter("notification.stream.processed", "type", type, "result", "failure").increment();
 			// ACK 하지 않음 → PEL 유지 → Recovery 가 재처리
 			throw e;
 		}

--- a/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/RedisStreamRecovery.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/redis/stream/recovery/RedisStreamRecovery.java
@@ -5,6 +5,8 @@ import com.sixpack.dorundorun.infra.redis.stream.consumer.RedisStreamMessageProc
 import com.sixpack.dorundorun.infra.redis.stream.dto.RedisStreamMessage;
 import com.sixpack.dorundorun.infra.redis.stream.util.RedisStreamMessageMapper;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
 @Component
@@ -32,14 +35,27 @@ public class RedisStreamRecovery {
 	private final RedisStreamMessageProcessor processor;
 	private final RedisStreamMessageMapper mapper;
 	private final DeadLetterQueueService deadLetterQueueService;
+	private final MeterRegistry meterRegistry;
+
+	// 매 recovery 주기(properties.recovery().intervalMs())마다 갱신되는 PEL 적체 개수.
+	// Prometheus가 스크랩할 때마다 Redis를 직접 조회하지 않도록 캐시된 값을 게이지로 노출한다.
+	private final AtomicLong pendingMessages = new AtomicLong(0);
+
+	@PostConstruct
+	private void registerGauge() {
+		meterRegistry.gauge("notification.stream.pending", pendingMessages);
+	}
 
 	public void reprocessPending(long minIdleMs, long count) {
 		PendingMessagesSummary summary = redisTemplate.opsForStream()
 			.pending(properties.key(), properties.group());
 
 		if (summary == null || summary.getTotalPendingMessages() == 0) {
+			pendingMessages.set(0);
 			return;
 		}
+
+		pendingMessages.set(summary.getTotalPendingMessages());
 
 		log.info("Pending messages: total={}, minId={}, maxId={}",
 			summary.getTotalPendingMessages(),
@@ -124,6 +140,7 @@ public class RedisStreamRecovery {
 					properties.group(),
 					pm.getId()
 				);
+				meterRegistry.counter("notification.stream.dlq").increment();
 				log.warn("Message moved to DLQ after {} retries: id={}", MAX_RETRY_COUNT, pm.getId());
 			} else {
 				log.error("Failed to move message to DLQ, keeping in PEL for retry: id={}", pm.getId());


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #145 
>관련 이슈 번호를 할당해주세요
>
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요.
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

* 알림 파이프라인(FCM, Redis Stream)에 장애가 나도 메트릭이 없어서 알 방법이 없었고,
actuator(`/actuator/prometheus`, `/actuator/metrics` 등)가 인증 없이 공개 포트(8081)로 그대로 노출되어 있었음

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
    - 커스텀 Micrometer 메트릭 3종 추가                                                                                                                                                                      
    - `fcm.send{result=success|failure}` - FCM 단일/멀티캐스트 발송 결과 (FcmServiceImpl)                                                                                                                  
    - `notification.stream.processed{type,result}` - Redis Stream 핸들러 처리 성공/실패 (RedisStreamMessageProcessor)                                                                                      
    - `notification.stream.dlq` - 최대 재시도 초과로 DLQ 이동된 건수 (RedisStreamRecovery)                                                                                                                 
    - `notification.stream.pending` - PEL 적체 게이지 (recovery 주기마다 캐시 갱신, 스크랩 시 Redis 직접 조회 안 함)                                                                                       
  - actuator를 `management.server.port=9091`로 메인 포트(8080)에서 분리                                                                                                                                    
    - 9091은 EC2에서 `-p`로 게시하지 않아 외부 인터넷에서 물리적으로 도달 불가, `monitoring` 도커 네트워크 내부의 Prometheus만 접근 가능                                                                   
    - Spring Security 룰 설정 실수에 의존하지 않는 구조적 차단                                                                                                                                             
  - EC2 `/opt/monitoring/prometheus/prometheus.yml`의 스크랩 타겟을 `sixpack:8080` → `sixpack:9091`로 갱신 (별도 반영, 코드 diff 아님)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
 - `Dockerfile`에 `EXPOSE 9091` 추가 (문서화 목적, 실제 접근 제어와는 무관)

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
*

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요
*

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [ ] To-Do Item


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 운영 모니터링 지표가 추가되어 FCM 전송, 스트림 처리 성공/실패, 대기 메시지, DLQ 이동 현황을 더 쉽게 확인할 수 있습니다.
* **Chores**
  * 컨테이너 실행 시 추가 포트가 노출되도록 설정이 확장되었습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->