### PR TITLE
fix: FCM 토큰 무효(UNREGISTERED) 시 재시도 대신 즉시 토큰 정리

### DIFF
--- a/src/main/java/com/sixpack/dorundorun/feature/notification/application/SendPushNotificationService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/notification/application/SendPushNotificationService.java
@@ -7,8 +7,12 @@ import org.springframework.stereotype.Service;
 
 import com.sixpack.dorundorun.feature.notification.exception.NotificationErrorCode;
 import com.sixpack.dorundorun.feature.user.application.FindUserByIdService;
+import com.sixpack.dorundorun.feature.user.application.InvalidateDeviceTokenService;
 import com.sixpack.dorundorun.feature.user.domain.User;
+import com.sixpack.dorundorun.global.exception.CustomException;
+import com.sixpack.dorundorun.infra.firebase.FcmErrorCode;
 import com.sixpack.dorundorun.infra.firebase.FcmMessage;
+import com.sixpack.dorundorun.infra.firebase.FcmMulticastResult;
 import com.sixpack.dorundorun.infra.firebase.FcmService;
 import com.sixpack.dorundorun.feature.notification.event.PushNotificationRequestedEvent;
 
@@ -22,6 +26,7 @@ public class SendPushNotificationService {
 
 	private final FcmService fcmService;
 	private final FindUserByIdService findUserByIdService;
+	private final InvalidateDeviceTokenService invalidateDeviceTokenService;
 
 	// 단일 사용자에게 푸시 알림 발송
 	public String send(
@@ -56,6 +61,19 @@ public class SendPushNotificationService {
 			log.info("FCM message sent successfully: recipientId={}, messageId={}, type={}",
 				event.recipientUserId(), messageId, event.notificationType());
 			return messageId;
+
+		} catch (CustomException e) {
+			// 죽은 토큰은 재시도해도 절대 성공하지 않으므로, 재시도 큐에 남기지 않고
+			// 토큰을 무효화한 뒤 정상 종료시켜 PEL/DLQ가 영구 실패 메시지로 오염되는 것을 막는다.
+			if (e.getErrorCode() == FcmErrorCode.FCM_TOKEN_UNREGISTERED) {
+				log.warn("Stale device token detected, invalidating: recipientId={}", event.recipientUserId());
+				invalidateDeviceTokenService.invalidate(event.recipientUserId());
+				return null;
+			}
+
+			log.error("Failed to send FCM message: recipientId={}, type={}",
+				event.recipientUserId(), event.notificationType(), e);
+			throw NotificationErrorCode.FAILED_TO_SEND_NOTIFICATION.format(event.notificationType());
 
 		} catch (Exception e) {
 			log.error("Failed to send FCM message: recipientId={}, type={}",
@@ -106,26 +124,28 @@ public class SendPushNotificationService {
 			return java.util.Collections.emptyList();
 		}
 
-		// 각 수신자의 Device Token 수집 및 검증
-		java.util.List<String> deviceTokens = recipientUserIds.stream()
-			.map(userId -> {
-				try {
-					User user = findUserByIdService.find(userId);
-					return user.getDeviceToken();
-				} catch (Exception e) {
-					log.warn("Failed to get device token for user: {}", userId, e);
-					return null;
+		// 각 수신자의 Device Token 수집 및 검증.
+		// distinct 토큰 -> userId 매핑을 같이 유지해야 멀티캐스트 응답에서 어느 유저의 토큰이
+		// 죽었는지 되짚어 무효화할 수 있다.
+		Map<String, Long> tokenToUserId = new java.util.LinkedHashMap<>();
+		recipientUserIds.forEach(userId -> {
+			try {
+				User user = findUserByIdService.find(userId);
+				String token = user.getDeviceToken();
+				if (token != null && !token.isEmpty() && fcmService.isValidToken(token)) {
+					tokenToUserId.putIfAbsent(token, userId);
 				}
-			})
-			.filter(token -> token != null && !token.isEmpty())
-			.filter(fcmService::isValidToken)
-			.distinct()
-			.toList();
+			} catch (Exception e) {
+				log.warn("Failed to get device token for user: {}", userId, e);
+			}
+		});
 
-		if (deviceTokens.isEmpty()) {
+		if (tokenToUserId.isEmpty()) {
 			log.warn("No valid device tokens found for {} recipients", recipientUserIds.size());
 			return java.util.Collections.emptyList();
 		}
+
+		java.util.List<String> deviceTokens = new java.util.ArrayList<>(tokenToUserId.keySet());
 
 		FcmMessage fcmMessage = buildFcmMessage(
 			"",
@@ -136,9 +156,19 @@ public class SendPushNotificationService {
 		);
 
 		try {
-			java.util.List<String> messageIds = fcmService.sendMulticastMessage(fcmMessage, deviceTokens);
-			log.info("Multicast FCM messages sent: count={}, type={}", messageIds.size(), event.notificationType());
-			return messageIds;
+			FcmMulticastResult result = fcmService.sendMulticastMessage(fcmMessage, deviceTokens);
+			log.info("Multicast FCM messages sent: count={}, type={}",
+				result.successMessageIds().size(), event.notificationType());
+
+			result.unregisteredTokens().forEach(token -> {
+				Long userId = tokenToUserId.get(token);
+				if (userId != null) {
+					log.warn("Stale device token detected in multicast, invalidating: recipientId={}", userId);
+					invalidateDeviceTokenService.invalidate(userId);
+				}
+			});
+
+			return result.successMessageIds();
 
 		} catch (Exception e) {
 			log.error("Failed to send multicast FCM messages: type={}", event.notificationType(), e);

--- a/src/main/java/com/sixpack/dorundorun/feature/user/application/InvalidateDeviceTokenService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/user/application/InvalidateDeviceTokenService.java
@@ -1,0 +1,28 @@
+package com.sixpack.dorundorun.feature.user.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sixpack.dorundorun.feature.user.dao.UserJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InvalidateDeviceTokenService {
+
+	private final UserJpaRepository userJpaRepository;
+
+	// FCM이 UNREGISTERED를 반환한 죽은 토큰을 제거한다.
+	// 같은 트랜잭션 안에서 다시 조회해서 영속 상태로 만든 뒤 수정해야 더티체킹이 적용된다.
+	@Transactional
+	public void invalidate(Long userId) {
+		userJpaRepository.findById(userId)
+			.ifPresent(user -> {
+				user.updateDeviceToken("");
+				log.info("Invalidated stale device token: userId={}", userId);
+			});
+	}
+}

--- a/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmErrorCode.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmErrorCode.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 public enum FcmErrorCode implements ErrorCode {
 
 	FCM_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 푸시 알림 전송에 실패했습니다."),
+	FCM_TOKEN_UNREGISTERED(HttpStatus.GONE, "FCM 토큰이 더 이상 유효하지 않습니다."),
 	FCM_INITIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase 초기화에 실패했습니다."),
 
 	FCM_DISABLED(HttpStatus.SERVICE_UNAVAILABLE, "FCM 서비스가 비활성화되어 있습니다."),

--- a/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmMulticastResult.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmMulticastResult.java
@@ -1,0 +1,11 @@
+package com.sixpack.dorundorun.infra.firebase;
+
+import java.util.List;
+
+// unregisteredTokens: UNREGISTERED(영구 무효)로 실패한 토큰 목록.
+// 호출부가 해당 토큰의 소유자를 찾아 무효화할 수 있도록 별도로 노출한다.
+public record FcmMulticastResult(
+	List<String> successMessageIds,
+	List<String> unregisteredTokens
+) {
+}

--- a/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmService.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmService.java
@@ -4,7 +4,7 @@ public interface FcmService {
 
 	String sendMessage(FcmMessage message);
 
-	java.util.List<String> sendMulticastMessage(FcmMessage message, java.util.List<String> deviceTokens);
+	FcmMulticastResult sendMulticastMessage(FcmMessage message, java.util.List<String> deviceTokens);
 
 	boolean isEnabled();
 

--- a/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmServiceImpl.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmServiceImpl.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Service;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
 import com.sixpack.dorundorun.global.config.firebase.FirebaseProperties;
@@ -46,6 +48,19 @@ public class FcmServiceImpl implements FcmService {
 			meterRegistry.counter("fcm.send", "result", "success").increment();
 			return messageId;
 
+		} catch (FirebaseMessagingException e) {
+			meterRegistry.counter("fcm.send", "result", "failure").increment();
+
+			// 토큰이 영구적으로 무효화된 경우(앱 삭제, 토큰 회전 등)는 재시도해도 절대 성공하지 않는다.
+			// 일반 전송 실패와 구분해서 호출부가 재시도 대신 토큰을 정리하도록 알린다.
+			if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
+				log.warn("FCM token unregistered, error: {}", e.getMessage());
+				throw new CustomException(FcmErrorCode.FCM_TOKEN_UNREGISTERED);
+			}
+
+			log.error("Failed to send FCM message, error: {}", e.getMessage(), e);
+			throw new CustomException(FcmErrorCode.FCM_SEND_FAILED);
+
 		} catch (Exception e) {
 			log.error("Failed to send FCM message, error: {}", e.getMessage(), e);
 			meterRegistry.counter("fcm.send", "result", "failure").increment();
@@ -54,13 +69,13 @@ public class FcmServiceImpl implements FcmService {
 	}
 
 	@Override
-	public List<String> sendMulticastMessage(FcmMessage message, List<String> deviceTokens) {
+	public FcmMulticastResult sendMulticastMessage(FcmMessage message, List<String> deviceTokens) {
 		if (!isEnabled()) {
 			throw new CustomException(FcmErrorCode.FCM_DISABLED);
 		}
 
 		if (deviceTokens == null || deviceTokens.isEmpty()) {
-			return new ArrayList<>();
+			return new FcmMulticastResult(new ArrayList<>(), new ArrayList<>());
 		}
 
 		List<String> uniqueTokens = deviceTokens.stream()
@@ -69,7 +84,7 @@ public class FcmServiceImpl implements FcmService {
 			.collect(Collectors.toList());
 
 		if (uniqueTokens.isEmpty()) {
-			return new ArrayList<>();
+			return new FcmMulticastResult(new ArrayList<>(), new ArrayList<>());
 		}
 
 		validateMessage(message);
@@ -80,14 +95,26 @@ public class FcmServiceImpl implements FcmService {
 
 			List<String> successMessageIds = new ArrayList<>();
 			List<String> failedTokens = new ArrayList<>();
+			List<String> unregisteredTokens = new ArrayList<>();
 
-			response.getResponses().forEach(sendResponse -> {
+			var sendResponses = response.getResponses();
+			for (int i = 0; i < sendResponses.size(); i++) {
+				var sendResponse = sendResponses.get(i);
+				String token = uniqueTokens.get(i);
+
 				if (sendResponse.isSuccessful()) {
 					successMessageIds.add(sendResponse.getMessageId());
-				} else {
-					failedTokens.add(sendResponse.getException().getMessage());
+					continue;
 				}
-			});
+
+				FirebaseMessagingException exception = sendResponse.getException();
+				failedTokens.add(exception.getMessage());
+
+				// 토큰이 영구적으로 무효화된 경우 - 재시도 대상이 아니라 호출부가 정리하도록 별도로 모은다.
+				if (exception.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
+					unregisteredTokens.add(token);
+				}
+			}
 
 			log.info("Multicast message sent. Success: {}, Failed: {}",
 				successMessageIds.size(), failedTokens.size());
@@ -99,7 +126,7 @@ public class FcmServiceImpl implements FcmService {
 			meterRegistry.counter("fcm.send", "result", "success").increment(successMessageIds.size());
 			meterRegistry.counter("fcm.send", "result", "failure").increment(failedTokens.size());
 
-			return successMessageIds;
+			return new FcmMulticastResult(successMessageIds, unregisteredTokens);
 
 		} catch (Exception e) {
 			log.error("Failed to send multicast FCM message, error: {}", e.getMessage(), e);

--- a/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmServiceStub.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/firebase/FcmServiceStub.java
@@ -32,7 +32,7 @@ public class FcmServiceStub implements FcmService {
     }
 
     @Override
-    public List<String> sendMulticastMessage(FcmMessage message, List<String> deviceTokens) {
+    public FcmMulticastResult sendMulticastMessage(FcmMessage message, List<String> deviceTokens) {
         try {
             Thread.sleep(FCM_LATENCY_MS);
         } catch (InterruptedException e) {
@@ -42,7 +42,7 @@ public class FcmServiceStub implements FcmService {
         for (int i = 0; i < deviceTokens.size(); i++) {
             ids.add("stub-" + i + "-" + System.nanoTime());
         }
-        return ids;
+        return new FcmMulticastResult(ids, new ArrayList<>());
     }
 
     @Override

--- a/src/main/java/com/sixpack/dorundorun/infra/firebase/NoOpFcmService.java
+++ b/src/main/java/com/sixpack/dorundorun/infra/firebase/NoOpFcmService.java
@@ -26,13 +26,13 @@ public class NoOpFcmService implements FcmService {
 	}
 
 	@Override
-	public List<String> sendMulticastMessage(FcmMessage message, List<String> deviceTokens) {
+	public FcmMulticastResult sendMulticastMessage(FcmMessage message, List<String> deviceTokens) {
 		log.warn("FCM is disabled. Message would have been sent to {} devices", deviceTokens.size());
 		List<String> mockIds = new ArrayList<>();
 		for (int i = 0; i < deviceTokens.size(); i++) {
 			mockIds.add("mock-message-id-" + i + "-" + System.nanoTime());
 		}
-		return mockIds;
+		return new FcmMulticastResult(mockIds, Collections.emptyList());
 	}
 
 	@Override


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #148 
>관련 이슈 번호를 할당해주세요
>
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요.
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

- FirebaseMessagingException의 Requested entity was not found`(MessagingErrorCode.UNREGISTERED)
   앱 삭제/토큰 회전으로 비활성화된 디바이스 토큰에 계속 푸시를 시도함
- 이건 재시도해도 절대 성공하지 않는 영구 실패인데, 
    현재 RedisStreamRecovery는 일시적 장애와 똑같이 취급해서 5회 백오프 재시도 후 DLQ로 보냄

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
  **단일 발송 경로**                                                                                                                                                                                       
  - `FcmErrorCode.FCM_TOKEN_UNREGISTERED` 추가                                                                                                                                                             
  - `FcmServiceImpl.sendMessage()`: `FirebaseMessagingException`의                                                                                                                                         
    `MessagingErrorCode.UNREGISTERED`를 별도로 잡아서 일반 전송 실패와 구분                                                                                                                                
  - `SendPushNotificationService.send()`: `FCM_TOKEN_UNREGISTERED`를 받으면                                                                                                                                
    재시도 큐(PEL)에 남기지 않고 즉시 정상 종료(ACK) + 토큰 무효화                                                                                                                                         
  - `InvalidateDeviceTokenService` 신규 - `@Transactional`로 유저를 다시                                                                                                                                   
    조회해서 영속 상태로 만든 뒤 토큰을 비움 (detached entity에 setter만                                                                                                                                   
    호출하면 더티체킹이 안 먹는 함정을 피하기 위함)                                                                                                                                                        
                                                                                                                                                                                                           
  **멀티캐스트 발송 경로**                                                                                                                                                                                 
  - `FcmMulticastResult` 레코드 신규 (`successMessageIds`, `unregisteredTokens`)                                                                                                                           
    - `FcmService` 인터페이스와 3개 구현체(`FcmServiceImpl`, `FcmServiceStub`,                                                                                                                             
      `NoOpFcmService`)의 `sendMulticastMessage()` 반환형을 `List<String>`에서                                                                                                                             
      이걸로 변경                                                                                                                                                                                          
  - `FcmServiceImpl.sendMulticastMessage()`: 응답을 인덱스 기반으로 순회해서                                                                                                                               
    토큰과 1:1 매칭, `UNREGISTERED`로 실패한 토큰만 별도로 모아서 반환                                                                                                                                     
  - `SendPushNotificationService.sendMultiple()`: 기존엔 토큰 리스트를                                                                                                                                     
    `.distinct()`로만 만들어서 유저 매핑이 끊겨 있었는데, `Map<String, Long>                                                                                                                               
    tokenToUserId`를 같이 유지하도록 바꿔서 죽은 토큰이 오면 어느 유저였는지                                                                                                                               
    되짚어 무효화

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* 없음

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
*

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요
*

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [ ] To-Do Item
