### PR TITLE
fix: 캐시 스탬피드 방지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.lettuce:lettuce-core'
 
+    // Caffeine (in-process single-flight 캐시)
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/sixpack/dorundorun/feature/friend/application/ReverseGeocodingService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/friend/application/ReverseGeocodingService.java
@@ -25,63 +25,63 @@ import java.util.concurrent.ThreadLocalRandom;
 @Service
 public class ReverseGeocodingService {
 
-    private static final String CACHE_KEY_PREFIX = "reverse-geocoding:";
-    private static final long LOCAL_CACHE_MAX_SIZE = 10_000;
-    private static final double TTL_JITTER_RATIO = 0.1;
+	private static final String CACHE_KEY_PREFIX = "reverse-geocoding:";
+	private static final long LOCAL_CACHE_MAX_SIZE = 10_000;
+	private static final double TTL_JITTER_RATIO = 0.1;
 
-    private final StringRedisTemplate redisTemplate;
-    private final NaverReverseGeocodingApi naverReverseGeocodingApi;
-    private final ObjectMapper objectMapper;
-    private final ReverseGeocodingProperties reverseGeocodingProperties;
+	private final StringRedisTemplate redisTemplate;
+	private final NaverReverseGeocodingApi naverReverseGeocodingApi;
+	private final ObjectMapper objectMapper;
+	private final ReverseGeocodingProperties reverseGeocodingProperties;
 
-    // 동일 좌표에 대한 동시 요청을 하나의 계산으로 합쳐 캐시 스탬피드를 방지하는 in-process single-flight 캐시
-    private final AsyncCache<String, AddressInfo> localCache;
+	// 동일 좌표에 대한 동시 요청을 하나의 계산으로 합쳐 캐시 스탬피드를 방지하는 in-process single-flight 캐시
+	private final AsyncCache<String, AddressInfo> localCache;
 
-    public ReverseGeocodingService(
-            StringRedisTemplate redisTemplate,
-            NaverReverseGeocodingApi naverReverseGeocodingApi,
-            ObjectMapper objectMapper,
-            ReverseGeocodingProperties reverseGeocodingProperties) {
-        this.redisTemplate = redisTemplate;
-        this.naverReverseGeocodingApi = naverReverseGeocodingApi;
-        this.objectMapper = objectMapper;
-        this.reverseGeocodingProperties = reverseGeocodingProperties;
-        this.localCache = Caffeine.newBuilder()
-                .maximumSize(LOCAL_CACHE_MAX_SIZE)
-                .expireAfterWrite(Duration.ofHours(reverseGeocodingProperties.cache().ttlHours()))
-                .buildAsync();
-    }
+	public ReverseGeocodingService(
+			StringRedisTemplate redisTemplate,
+			NaverReverseGeocodingApi naverReverseGeocodingApi,
+			ObjectMapper objectMapper,
+			ReverseGeocodingProperties reverseGeocodingProperties) {
+		this.redisTemplate = redisTemplate;
+		this.naverReverseGeocodingApi = naverReverseGeocodingApi;
+		this.objectMapper = objectMapper;
+		this.reverseGeocodingProperties = reverseGeocodingProperties;
+		this.localCache = Caffeine.newBuilder()
+				.maximumSize(LOCAL_CACHE_MAX_SIZE)
+				.expireAfterWrite(Duration.ofHours(reverseGeocodingProperties.cache().ttlHours()))
+				.buildAsync();
+	}
 
-    public CompletableFuture<AddressInfo> addressByCoordinatesAsync(
-            Double latitude, Double longitude, Executor executor) {
+	public CompletableFuture<AddressInfo> addressByCoordinatesAsync(
+			Double latitude, Double longitude, Executor executor) {
 
-        String cacheKey = CACHE_KEY_PREFIX + CoordinateUtil.roundToKey(latitude, longitude);
+		String cacheKey = CACHE_KEY_PREFIX + CoordinateUtil.roundToKey(latitude, longitude);
 
-        // 같은 키로 동시에 들어온 요청은 진행 중인 future에 합류하며, 로딩 함수는 키당 한 번만 실행됨
-        return localCache.get(cacheKey,
-                (key, ignoredExecutor) -> CompletableFuture.supplyAsync(
-                        () -> loadAddress(key, latitude, longitude), executor));
-    }
+		// 같은 키로 동시에 들어온 요청은 진행 중인 future에 합류하며, 로딩 함수는 키당 한 번만 실행됨
+		return localCache.get(cacheKey,
+				(key, ignoredExecutor) -> CompletableFuture.supplyAsync(
+						() -> loadAddress(key, latitude, longitude), executor));
+	}
 
-    private AddressInfo loadAddress(String cacheKey, Double latitude, Double longitude) {
-        // 1단계: Redis 캐시 조회
-        try {
-            String cachedJson = redisTemplate.opsForValue().get(cacheKey);
-            if (cachedJson != null) {
-                AddressInfo cached = parseFromCache(cachedJson);
-                if (cached != null) {
-                    return cached;
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Redis 캐시 조회 실패, API 호출로 대체: key={}, error={}", cacheKey, e.getMessage());
-        }
+	private AddressInfo loadAddress(String cacheKey, Double latitude, Double longitude) {
+		// 1단계: Redis 캐시 조회
+		try {
+			String cachedJson = redisTemplate.opsForValue().get(cacheKey);
+			if (cachedJson != null) {
+				AddressInfo cached = parseFromCache(cachedJson);
+				if (cached != null) {
+					return cached;
+				}
+			}
+		} catch (Exception e) {
+			log.warn("Redis 캐시 조회 실패, API 호출로 대체: key={}, error={}", cacheKey, e.getMessage());
+		}
 
-        // 2단계: 캐시 미스 → API 호출 (retry 포함)
-        AddressInfo result = callWithRetry(latitude, longitude);
-        cacheAddressInfo(cacheKey, result);
-        return result;
-    }
+		// 2단계: 캐시 미스 → API 호출 (retry 포함)
+		AddressInfo result = callWithRetry(latitude, longitude);
+		cacheAddressInfo(cacheKey, result);
+		return result;
+	}
 
     private AddressInfo callWithRetry(Double latitude, Double longitude) {
         int retryAttempts = reverseGeocodingProperties.api().retryAttempts();
@@ -147,22 +147,22 @@ public class ReverseGeocodingService {
                 .trim();
     }
 
-    private void cacheAddressInfo(String cacheKey, AddressInfo addressInfo) {
-        try {
-            String json = objectMapper.writeValueAsString(addressInfo);
-            redisTemplate.opsForValue().set(cacheKey, json, jitteredTtl());
-        } catch (Exception e) {
-            log.warn("Redis 캐시 저장 실패 (무시): key={}, error={}", cacheKey, e.getMessage());
-        }
-    }
+	private void cacheAddressInfo(String cacheKey, AddressInfo addressInfo) {
+		try {
+			String json = objectMapper.writeValueAsString(addressInfo);
+			redisTemplate.opsForValue().set(cacheKey, json, jitteredTtl());
+		} catch (Exception e) {
+			log.warn("Redis 캐시 저장 실패 (무시): key={}, error={}", cacheKey, e.getMessage());
+		}
+	}
 
-    // 같은 시점에 채워진 캐시 키들이 한꺼번에 만료되어 API 호출이 몰리는 것을 방지하기 위한 TTL 지터(±10%)
-    private Duration jitteredTtl() {
-        long ttlSeconds = Duration.ofHours(reverseGeocodingProperties.cache().ttlHours()).toSeconds();
-        long jitterRangeSeconds = (long) (ttlSeconds * TTL_JITTER_RATIO);
-        long jitterSeconds = ThreadLocalRandom.current().nextLong(-jitterRangeSeconds, jitterRangeSeconds + 1);
-        return Duration.ofSeconds(ttlSeconds + jitterSeconds);
-    }
+	// 같은 시점에 채워진 캐시 키들이 한꺼번에 만료되어 API 호출이 몰리는 것을 방지하기 위한 TTL 지터(±10%)
+	private Duration jitteredTtl() {
+		long ttlSeconds = Duration.ofHours(reverseGeocodingProperties.cache().ttlHours()).toSeconds();
+		long jitterRangeSeconds = (long) (ttlSeconds * TTL_JITTER_RATIO);
+		long jitterSeconds = ThreadLocalRandom.current().nextLong(-jitterRangeSeconds, jitterRangeSeconds + 1);
+		return Duration.ofSeconds(ttlSeconds + jitterSeconds);
+	}
 
     private AddressInfo parseFromCache(String json) {
         try {

--- a/src/main/java/com/sixpack/dorundorun/feature/friend/application/ReverseGeocodingService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/friend/application/ReverseGeocodingService.java
@@ -1,12 +1,13 @@
 package com.sixpack.dorundorun.feature.friend.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.sixpack.dorundorun.global.config.naver.ReverseGeocodingProperties;
 import com.sixpack.dorundorun.global.utils.CoordinateUtil;
 import com.sixpack.dorundorun.infra.naver.api.NaverReverseGeocodingApi;
 import com.sixpack.dorundorun.infra.naver.dto.AddressInfo;
 import com.sixpack.dorundorun.infra.naver.dto.response.ReverseGeocodingResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -18,43 +19,68 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class ReverseGeocodingService {
+
+    private static final String CACHE_KEY_PREFIX = "reverse-geocoding:";
+    private static final long LOCAL_CACHE_MAX_SIZE = 10_000;
+    private static final double TTL_JITTER_RATIO = 0.1;
 
     private final StringRedisTemplate redisTemplate;
     private final NaverReverseGeocodingApi naverReverseGeocodingApi;
     private final ObjectMapper objectMapper;
     private final ReverseGeocodingProperties reverseGeocodingProperties;
 
-    private static final String CACHE_KEY_PREFIX = "reverse-geocoding:";
+    // 동일 좌표에 대한 동시 요청을 하나의 계산으로 합쳐 캐시 스탬피드를 방지하는 in-process single-flight 캐시
+    private final AsyncCache<String, AddressInfo> localCache;
+
+    public ReverseGeocodingService(
+            StringRedisTemplate redisTemplate,
+            NaverReverseGeocodingApi naverReverseGeocodingApi,
+            ObjectMapper objectMapper,
+            ReverseGeocodingProperties reverseGeocodingProperties) {
+        this.redisTemplate = redisTemplate;
+        this.naverReverseGeocodingApi = naverReverseGeocodingApi;
+        this.objectMapper = objectMapper;
+        this.reverseGeocodingProperties = reverseGeocodingProperties;
+        this.localCache = Caffeine.newBuilder()
+                .maximumSize(LOCAL_CACHE_MAX_SIZE)
+                .expireAfterWrite(Duration.ofHours(reverseGeocodingProperties.cache().ttlHours()))
+                .buildAsync();
+    }
 
     public CompletableFuture<AddressInfo> addressByCoordinatesAsync(
             Double latitude, Double longitude, Executor executor) {
 
         String cacheKey = CACHE_KEY_PREFIX + CoordinateUtil.roundToKey(latitude, longitude);
 
-        return CompletableFuture.supplyAsync(() -> {
-            // 1단계: Redis 캐시 조회
-            try {
-                String cachedJson = redisTemplate.opsForValue().get(cacheKey);
-                if (cachedJson != null) {
-                    AddressInfo cached = parseFromCache(cachedJson);
-                    if (cached != null) {
-                        return cached;
-                    }
-                }
-            } catch (Exception e) {
-                log.warn("Redis 캐시 조회 실패, API 호출로 대체: key={}, error={}", cacheKey, e.getMessage());
-            }
+        // 같은 키로 동시에 들어온 요청은 진행 중인 future에 합류하며, 로딩 함수는 키당 한 번만 실행됨
+        return localCache.get(cacheKey,
+                (key, ignoredExecutor) -> CompletableFuture.supplyAsync(
+                        () -> loadAddress(key, latitude, longitude), executor));
+    }
 
-            // 2단계: 캐시 미스 → API 호출 (retry 포함)
-            AddressInfo result = callWithRetry(latitude, longitude);
-            cacheAddressInfo(cacheKey, result);
-            return result;
-        }, executor);
+    private AddressInfo loadAddress(String cacheKey, Double latitude, Double longitude) {
+        // 1단계: Redis 캐시 조회
+        try {
+            String cachedJson = redisTemplate.opsForValue().get(cacheKey);
+            if (cachedJson != null) {
+                AddressInfo cached = parseFromCache(cachedJson);
+                if (cached != null) {
+                    return cached;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Redis 캐시 조회 실패, API 호출로 대체: key={}, error={}", cacheKey, e.getMessage());
+        }
+
+        // 2단계: 캐시 미스 → API 호출 (retry 포함)
+        AddressInfo result = callWithRetry(latitude, longitude);
+        cacheAddressInfo(cacheKey, result);
+        return result;
     }
 
     private AddressInfo callWithRetry(Double latitude, Double longitude) {
@@ -124,11 +150,18 @@ public class ReverseGeocodingService {
     private void cacheAddressInfo(String cacheKey, AddressInfo addressInfo) {
         try {
             String json = objectMapper.writeValueAsString(addressInfo);
-            long ttlHours = reverseGeocodingProperties.cache().ttlHours();
-            redisTemplate.opsForValue().set(cacheKey, json, Duration.ofHours(ttlHours));
+            redisTemplate.opsForValue().set(cacheKey, json, jitteredTtl());
         } catch (Exception e) {
             log.warn("Redis 캐시 저장 실패 (무시): key={}, error={}", cacheKey, e.getMessage());
         }
+    }
+
+    // 같은 시점에 채워진 캐시 키들이 한꺼번에 만료되어 API 호출이 몰리는 것을 방지하기 위한 TTL 지터(±10%)
+    private Duration jitteredTtl() {
+        long ttlSeconds = Duration.ofHours(reverseGeocodingProperties.cache().ttlHours()).toSeconds();
+        long jitterRangeSeconds = (long) (ttlSeconds * TTL_JITTER_RATIO);
+        long jitterSeconds = ThreadLocalRandom.current().nextLong(-jitterRangeSeconds, jitterRangeSeconds + 1);
+        return Duration.ofSeconds(ttlSeconds + jitterSeconds);
     }
 
     private AddressInfo parseFromCache(String json) {

--- a/src/test/java/com/sixpack/dorundorun/feature/friend/application/ReverseGeocodingServiceStampedeTest.java
+++ b/src/test/java/com/sixpack/dorundorun/feature/friend/application/ReverseGeocodingServiceStampedeTest.java
@@ -1,0 +1,103 @@
+package com.sixpack.dorundorun.feature.friend.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sixpack.dorundorun.global.config.naver.ReverseGeocodingProperties;
+import com.sixpack.dorundorun.infra.naver.api.NaverReverseGeocodingApi;
+import com.sixpack.dorundorun.infra.naver.dto.response.ReverseGeocodingResponse;
+
+@DisplayName("ReverseGeocodingService 캐시 스탬피드 재현 테스트")
+class ReverseGeocodingServiceStampedeTest {
+
+	private static final double LATITUDE = 37.4979;
+	private static final double LONGITUDE = 127.0276;
+	private static final int CONCURRENT_REQUESTS = 20;
+
+	@Mock
+	private StringRedisTemplate redisTemplate;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	@Mock
+	private NaverReverseGeocodingApi naverReverseGeocodingApi;
+
+	private ReverseGeocodingService reverseGeocodingService;
+	private ExecutorService executor;
+	private AtomicInteger apiCallCount;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		executor = Executors.newFixedThreadPool(CONCURRENT_REQUESTS);
+		apiCallCount = new AtomicInteger(0);
+
+		// 캐시가 항상 비어있는 상황(콜드 캐시 / 동시 미스)을 시뮬레이션
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(anyString())).thenReturn(null);
+
+		// API는 호출될 때마다 지연을 주어 동시 호출 구간을 넓힘
+		when(naverReverseGeocodingApi.reverseGeocode(anyDouble(), anyDouble()))
+			.thenAnswer(invocation -> {
+				apiCallCount.incrementAndGet();
+				Thread.sleep(100);
+				return fakeResponse();
+			});
+
+		ReverseGeocodingProperties.Cache cacheProperties =
+			new ReverseGeocodingProperties.Cache(1, true, 3);
+		ReverseGeocodingProperties.Api apiProperties =
+			new ReverseGeocodingProperties.Api(CONCURRENT_REQUESTS, 0, 0, "주소 미상");
+		ReverseGeocodingProperties properties =
+			new ReverseGeocodingProperties(cacheProperties, apiProperties);
+
+		reverseGeocodingService = new ReverseGeocodingService(
+			redisTemplate, naverReverseGeocodingApi, new ObjectMapper(), properties);
+	}
+
+	@AfterEach
+	void tearDown() {
+		executor.shutdownNow();
+	}
+
+	@Test
+	@DisplayName("같은 좌표에 대한 동시 요청은 외부 API를 단 한 번만 호출해야 한다")
+	void concurrentRequestsForSameCoordinate_shouldCallApiOnlyOnce() {
+		CompletableFuture<?>[] futures = new CompletableFuture[CONCURRENT_REQUESTS];
+		for (int i = 0; i < CONCURRENT_REQUESTS; i++) {
+			futures[i] = reverseGeocodingService.addressByCoordinatesAsync(LATITUDE, LONGITUDE, executor);
+		}
+
+		CompletableFuture.allOf(futures).join();
+
+		assertEquals(1, apiCallCount.get(),
+			"동시 요청 " + CONCURRENT_REQUESTS + "건 중 API 호출은 1회여야 하지만 " + apiCallCount.get() + "회 발생함 (캐시 스탬피드)");
+	}
+
+	private ReverseGeocodingResponse fakeResponse() {
+		ReverseGeocodingResponse.Area area1 = new ReverseGeocodingResponse.Area("서울특별시");
+		ReverseGeocodingResponse.Area area2 = new ReverseGeocodingResponse.Area("마포구");
+		ReverseGeocodingResponse.Region region = new ReverseGeocodingResponse.Region(area1, area2, null);
+		ReverseGeocodingResponse.Result result = new ReverseGeocodingResponse.Result(region);
+		return new ReverseGeocodingResponse(null, List.of(result));
+	}
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #151 
>관련 이슈 번호를 할당해주세요
>
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요.
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

*  ReverseGeocodingService.addressByCoordinatesAsync는 캐시 미스 시 동시 요청을
   보호하는 장치가 없어서, 같은 좌표 그리드(roundToKey)에 여러 요청이 동시에 들어오면
   캐시 스탬피드가 발생해 Naver Reverse Geocoding API가 중복 호출될 수 있었습니다.
*  친구 러닝 현황 조회 시 같은 그리드에 여러 명이 위치하는 경우 실제로 재현됩니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
  - 같은 좌표 키에 대한 동시 요청을 하나의 계산으로 합치는 Caffeine `AsyncCache`            
    기반 in-process single-flight 캐시를 추가했습니다. (`ReverseGeocodingService`)                                         
  - 동시에 캐싱된 키들이 한 번에 만료되어 API 호출이 몰리는 걸 완화하기 위해
    Redis 캐시 TTL에 ±10% 지터를 적용했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
  - `com.github.ben-manes.caffeine:caffeine` 의존성 추

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
*

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요
*

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [ ] To-Do Item


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 동일한 위치에 대한 동시 요청을 더 효율적으로 처리해, 응답 안정성을 높였습니다.
  * 캐시 만료 시점이 한꺼번에 몰리지 않도록 개선해, 외부 호출 부담을 줄였습니다.

* **Bug Fixes**
  * 위치 정보 조회가 동시에 많이 발생해도 중복 요청이 생기지 않도록 수정했습니다.
  * 캐시 조회 실패 시에도 위치 정보가 정상적으로 다시 조회되도록 처리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->