### PR TITLE
feat: 연속 방문 스트릭(출석 체크인) API 추가

### DIFF
--- a/src/main/java/com/sixpack/dorundorun/feature/attendance/api/AttendanceApi.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/attendance/api/AttendanceApi.java
@@ -1,0 +1,24 @@
+package com.sixpack.dorundorun.feature.attendance.api;
+
+import com.sixpack.dorundorun.feature.attendance.dto.response.CheckInResponse;
+import com.sixpack.dorundorun.feature.user.domain.User;
+import com.sixpack.dorundorun.global.aop.annotation.CurrentUser;
+import com.sixpack.dorundorun.global.response.DorunResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[출석 체크 관련]")
+public interface AttendanceApi {
+
+	@Operation(summary = "출석 체크인", description = "로그인된 사용자의 오늘 출석을 기록하고, 갱신된 연속 방문 일수를 반환합니다. 하루에 여러 번 호출해도 안전합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "체크인 성공")
+	})
+	DorunResponse<CheckInResponse> checkIn(
+		@Parameter(hidden = true) @CurrentUser User user
+	);
+}

--- a/src/main/java/com/sixpack/dorundorun/feature/attendance/api/AttendanceController.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/attendance/api/AttendanceController.java
@@ -1,0 +1,27 @@
+package com.sixpack.dorundorun.feature.attendance.api;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sixpack.dorundorun.feature.attendance.application.CheckInService;
+import com.sixpack.dorundorun.feature.attendance.dto.response.CheckInResponse;
+import com.sixpack.dorundorun.feature.user.domain.User;
+import com.sixpack.dorundorun.global.aop.annotation.CurrentUser;
+import com.sixpack.dorundorun.global.response.DorunResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AttendanceController implements AttendanceApi {
+
+	private final CheckInService checkInService;
+
+	@PostMapping("/api/attendance/check-in")
+	public DorunResponse<CheckInResponse> checkIn(
+		@CurrentUser User user
+	) {
+		CheckInResponse response = checkInService.checkIn(user);
+		return DorunResponse.success("출석 체크가 완료되었습니다.", response);
+	}
+}

--- a/src/main/java/com/sixpack/dorundorun/feature/attendance/application/CheckInService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/attendance/application/CheckInService.java
@@ -1,0 +1,61 @@
+package com.sixpack.dorundorun.feature.attendance.application;
+
+import java.time.LocalDate;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sixpack.dorundorun.feature.attendance.dao.AttendanceStreakJpaRepository;
+import com.sixpack.dorundorun.feature.attendance.domain.AttendanceStreak;
+import com.sixpack.dorundorun.feature.attendance.dto.response.CheckInResponse;
+import com.sixpack.dorundorun.feature.user.domain.User;
+import com.sixpack.dorundorun.global.utils.KoreaTimeHandler;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CheckInService {
+
+	private final AttendanceStreakJpaRepository attendanceStreakJpaRepository;
+	private final KoreaTimeHandler koreaTimeHandler;
+
+	@Transactional
+	public CheckInResponse checkIn(User user) {
+		LocalDate today = koreaTimeHandler.now();
+
+		AttendanceStreak streak = attendanceStreakJpaRepository.findByUserIdForUpdate(user.getId())
+			.orElseGet(() -> createInitialStreak(user));
+
+		if (streak.isCheckedInToday(today)) {
+			return toResponse(streak, false);
+		}
+
+		if (streak.isConsecutive(today)) {
+			streak.continueStreak(today);
+		} else {
+			streak.resetStreak(today);
+		}
+
+		return toResponse(streak, true);
+	}
+
+	private AttendanceStreak createInitialStreak(User user) {
+		try {
+			return attendanceStreakJpaRepository.save(AttendanceStreak.builder()
+				.user(user)
+				.lastCheckinDate(LocalDate.MIN)
+				.streakCount(0)
+				.longestStreak(0)
+				.build());
+		} catch (DataIntegrityViolationException e) {
+			return attendanceStreakJpaRepository.findByUserIdForUpdate(user.getId())
+				.orElseThrow(() -> e);
+		}
+	}
+
+	private CheckInResponse toResponse(AttendanceStreak streak, boolean isFirstCheckInToday) {
+		return new CheckInResponse(streak.getStreakCount(), streak.getLongestStreak(), isFirstCheckInToday);
+	}
+}

--- a/src/main/java/com/sixpack/dorundorun/feature/attendance/application/CheckInService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/attendance/application/CheckInService.java
@@ -2,8 +2,8 @@ package com.sixpack.dorundorun.feature.attendance.application;
 
 import java.time.LocalDate;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sixpack.dorundorun.feature.attendance.dao.AttendanceStreakJpaRepository;
@@ -21,12 +21,14 @@ public class CheckInService {
 	private final AttendanceStreakJpaRepository attendanceStreakJpaRepository;
 	private final KoreaTimeHandler koreaTimeHandler;
 
-	@Transactional
+	// 존재하지 않는 유니크 키에 여러 트랜잭션이 동시에 INSERT ON DUPLICATE KEY UPDATE를 시도할 때
+	// REPEATABLE READ의 갭 락으로 인한 데드락을 피하기 위해 READ COMMITTED로 낮춘다.
+	@Transactional(isolation = Isolation.READ_COMMITTED)
 	public CheckInResponse checkIn(User user) {
 		LocalDate today = koreaTimeHandler.now();
 
 		AttendanceStreak streak = attendanceStreakJpaRepository.findByUserIdForUpdate(user.getId())
-			.orElseGet(() -> createInitialStreak(user));
+			.orElseGet(() -> createStreakForFirstEverCheckIn(user, today));
 
 		if (streak.isCheckedInToday(today)) {
 			return toResponse(streak, false);
@@ -41,18 +43,11 @@ public class CheckInService {
 		return toResponse(streak, true);
 	}
 
-	private AttendanceStreak createInitialStreak(User user) {
-		try {
-			return attendanceStreakJpaRepository.save(AttendanceStreak.builder()
-				.user(user)
-				.lastCheckinDate(LocalDate.MIN)
-				.streakCount(0)
-				.longestStreak(0)
-				.build());
-		} catch (DataIntegrityViolationException e) {
-			return attendanceStreakJpaRepository.findByUserIdForUpdate(user.getId())
-				.orElseThrow(() -> e);
-		}
+	private AttendanceStreak createStreakForFirstEverCheckIn(User user, LocalDate today) {
+		attendanceStreakJpaRepository.insertIfAbsent(user.getId(), today.minusDays(1));
+		return attendanceStreakJpaRepository.findByUserIdForUpdate(user.getId())
+			.orElseThrow(() -> new IllegalStateException(
+				"attendance streak row missing after upsert, userId=" + user.getId()));
 	}
 
 	private CheckInResponse toResponse(AttendanceStreak streak, boolean isFirstCheckInToday) {

--- a/src/main/java/com/sixpack/dorundorun/feature/attendance/dao/AttendanceStreakJpaRepository.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/attendance/dao/AttendanceStreakJpaRepository.java
@@ -1,9 +1,11 @@
 package com.sixpack.dorundorun.feature.attendance.dao;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,4 +22,12 @@ public interface AttendanceStreakJpaRepository extends JpaRepository<AttendanceS
 	Optional<AttendanceStreak> findByUserId(Long userId);
 
 	int deleteByUserId(Long userId);
+
+	@Modifying
+	@Query(value = """
+		INSERT INTO attendance_streak (user_id, last_checkin_date, streak_count, longest_streak, created_at, updated_at)
+		VALUES (:userId, :sentinelDate, 0, 0, NOW(), NOW())
+		ON DUPLICATE KEY UPDATE id = id
+		""", nativeQuery = true)
+	void insertIfAbsent(@Param("userId") Long userId, @Param("sentinelDate") LocalDate sentinelDate);
 }

--- a/src/main/java/com/sixpack/dorundorun/feature/attendance/dao/AttendanceStreakJpaRepository.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/attendance/dao/AttendanceStreakJpaRepository.java
@@ -1,0 +1,23 @@
+package com.sixpack.dorundorun.feature.attendance.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.sixpack.dorundorun.feature.attendance.domain.AttendanceStreak;
+
+import jakarta.persistence.LockModeType;
+
+public interface AttendanceStreakJpaRepository extends JpaRepository<AttendanceStreak, Long> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT s FROM AttendanceStreak s WHERE s.user.id = :userId")
+	Optional<AttendanceStreak> findByUserIdForUpdate(@Param("userId") Long userId);
+
+	Optional<AttendanceStreak> findByUserId(Long userId);
+
+	int deleteByUserId(Long userId);
+}

--- a/src/main/java/com/sixpack/dorundorun/feature/attendance/domain/AttendanceStreak.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/attendance/domain/AttendanceStreak.java
@@ -1,0 +1,74 @@
+package com.sixpack.dorundorun.feature.attendance.domain;
+
+import java.time.LocalDate;
+
+import com.sixpack.dorundorun.feature.common.model.BaseTimeEntity;
+import com.sixpack.dorundorun.feature.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "attendance_streak", uniqueConstraints = {
+	@UniqueConstraint(name = "uk_attendance_streak_user", columnNames = {"user_id"})
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class AttendanceStreak extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "last_checkin_date", nullable = false)
+	private LocalDate lastCheckinDate;
+
+	@Column(name = "streak_count", nullable = false)
+	private int streakCount;
+
+	@Column(name = "longest_streak", nullable = false)
+	private int longestStreak;
+
+	public boolean isCheckedInToday(LocalDate today) {
+		return today.equals(lastCheckinDate);
+	}
+
+	public boolean isConsecutive(LocalDate today) {
+		return lastCheckinDate.equals(today.minusDays(1));
+	}
+
+	public void continueStreak(LocalDate today) {
+		this.streakCount += 1;
+		this.lastCheckinDate = today;
+		if (this.streakCount > this.longestStreak) {
+			this.longestStreak = this.streakCount;
+		}
+	}
+
+	public void resetStreak(LocalDate today) {
+		this.streakCount = 1;
+		this.lastCheckinDate = today;
+		if (this.longestStreak < 1) {
+			this.longestStreak = 1;
+		}
+	}
+}

--- a/src/main/java/com/sixpack/dorundorun/feature/attendance/dto/response/CheckInResponse.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/attendance/dto/response/CheckInResponse.java
@@ -1,0 +1,16 @@
+package com.sixpack.dorundorun.feature.attendance.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "출석 체크인 응답 DTO")
+public record CheckInResponse(
+	@Schema(description = "현재 연속 방문 일수", example = "5")
+	int streakCount,
+
+	@Schema(description = "역대 최장 연속 방문 일수", example = "12")
+	int longestStreak,
+
+	@Schema(description = "오늘 첫 체크인 여부", example = "true")
+	boolean isFirstCheckInToday
+) {
+}

--- a/src/main/java/com/sixpack/dorundorun/feature/auth/application/WithdrawService.java
+++ b/src/main/java/com/sixpack/dorundorun/feature/auth/application/WithdrawService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.sixpack.dorundorun.feature.attendance.dao.AttendanceStreakJpaRepository;
 import com.sixpack.dorundorun.feature.feed.dao.FeedJpaRepository;
 import com.sixpack.dorundorun.feature.feed.dao.ReactionJpaRepository;
 import com.sixpack.dorundorun.feature.feed.domain.Feed;
@@ -32,6 +33,7 @@ public class WithdrawService {
 	private final RunSessionJpaRepository runSessionJpaRepository;
 	private final RunSegmentJpaRepository runSegmentJpaRepository;
 	private final NotificationJpaRepository notificationJpaRepository;
+	private final AttendanceStreakJpaRepository attendanceStreakJpaRepository;
 	private final RedisTokenRepository redisTokenRepository;
 	private final S3Service s3Service;
 
@@ -42,6 +44,7 @@ public class WithdrawService {
 		deleteReactions(userId);
 		deleteFeeds(userId);
 		deleteFriends(userId);
+		deleteAttendanceStreak(userId);
 		deleteRunSegments(userId);
 		deleteRunSessions(userId);
 		deleteNotifications(userId);
@@ -61,6 +64,10 @@ public class WithdrawService {
 	private void deleteFriends(Long userId) {
 		friendJpaRepository.deleteByUserId(userId);
 		friendJpaRepository.deleteByFriendId(userId);
+	}
+
+	private void deleteAttendanceStreak(Long userId) {
+		attendanceStreakJpaRepository.deleteByUserId(userId);
 	}
 
 	private void deleteRunSegments(Long userId) {

--- a/src/test/java/com/sixpack/dorundorun/feature/attendance/application/CheckInConcurrencyIntegrationTest.java
+++ b/src/test/java/com/sixpack/dorundorun/feature/attendance/application/CheckInConcurrencyIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.sixpack.dorundorun.feature.attendance.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.sixpack.dorundorun.feature.attendance.dao.AttendanceStreakJpaRepository;
+import com.sixpack.dorundorun.feature.attendance.domain.AttendanceStreak;
+import com.sixpack.dorundorun.feature.user.dao.UserJpaRepository;
+import com.sixpack.dorundorun.feature.user.domain.User;
+import com.sixpack.dorundorun.global.service.ServiceTest;
+import com.sixpack.dorundorun.global.utils.KoreaTimeHandler;
+
+@DisplayName("CheckInService 동시성 통합 테스트")
+class CheckInConcurrencyIntegrationTest extends ServiceTest {
+
+	private static final int CONCURRENT_REQUESTS = 10;
+
+	@Autowired
+	private CheckInService checkInService;
+
+	@Autowired
+	private AttendanceStreakJpaRepository attendanceStreakJpaRepository;
+
+	@Autowired
+	private UserJpaRepository userJpaRepository;
+
+	@Autowired
+	private KoreaTimeHandler koreaTimeHandler;
+
+	private User testUser;
+
+	@BeforeEach
+	void setUp() {
+		testUser = User.builder()
+			.phoneNumber("010-0000-0000")
+			.code("ATTEND001")
+			.nickname("출석테스터")
+			.deviceToken("test-device-token-attendance")
+			.build();
+		testUser = userJpaRepository.save(testUser);
+	}
+
+	@AfterEach
+	void tearDown() {
+		attendanceStreakJpaRepository.deleteAll();
+		userJpaRepository.delete(testUser);
+	}
+
+	@Test
+	@DisplayName("같은 유저가 동시에 여러 번 체크인해도 스트릭은 정확히 1만 증가한다")
+	void checkIn_concurrentRequests_incrementsStreakExactlyOnce() throws InterruptedException {
+		LocalDate today = koreaTimeHandler.now();
+		attendanceStreakJpaRepository.save(AttendanceStreak.builder()
+			.user(testUser)
+			.lastCheckinDate(today.minusDays(1))
+			.streakCount(4)
+			.longestStreak(4)
+			.build());
+
+		ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_REQUESTS);
+		CountDownLatch readyLatch = new CountDownLatch(CONCURRENT_REQUESTS);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(CONCURRENT_REQUESTS);
+
+		for (int i = 0; i < CONCURRENT_REQUESTS; i++) {
+			executor.submit(() -> {
+				readyLatch.countDown();
+				try {
+					startLatch.await();
+					checkInService.checkIn(testUser);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				} finally {
+					doneLatch.countDown();
+				}
+			});
+		}
+
+		readyLatch.await();
+		startLatch.countDown();
+		boolean completed = doneLatch.await(30, TimeUnit.SECONDS);
+		executor.shutdown();
+
+		assertThat(completed).isTrue();
+
+		AttendanceStreak result = attendanceStreakJpaRepository.findByUserId(testUser.getId())
+			.orElseThrow();
+		assertThat(result.getStreakCount()).isEqualTo(5);
+		assertThat(result.getLongestStreak()).isEqualTo(5);
+		assertThat(result.getLastCheckinDate()).isEqualTo(today);
+	}
+}

--- a/src/test/java/com/sixpack/dorundorun/feature/attendance/application/CheckInConcurrencyIntegrationTest.java
+++ b/src/test/java/com/sixpack/dorundorun/feature/attendance/application/CheckInConcurrencyIntegrationTest.java
@@ -3,9 +3,12 @@ package com.sixpack.dorundorun.feature.attendance.application;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
@@ -59,7 +62,7 @@ class CheckInConcurrencyIntegrationTest extends ServiceTest {
 
 	@Test
 	@DisplayName("같은 유저가 동시에 여러 번 체크인해도 스트릭은 정확히 1만 증가한다")
-	void checkIn_concurrentRequests_incrementsStreakExactlyOnce() throws InterruptedException {
+	void checkIn_concurrentRequests_incrementsStreakExactlyOnce() throws Exception {
 		LocalDate today = koreaTimeHandler.now();
 		attendanceStreakJpaRepository.save(AttendanceStreak.builder()
 			.user(testUser)
@@ -68,36 +71,50 @@ class CheckInConcurrencyIntegrationTest extends ServiceTest {
 			.longestStreak(4)
 			.build());
 
-		ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_REQUESTS);
-		CountDownLatch readyLatch = new CountDownLatch(CONCURRENT_REQUESTS);
-		CountDownLatch startLatch = new CountDownLatch(1);
-		CountDownLatch doneLatch = new CountDownLatch(CONCURRENT_REQUESTS);
-
-		for (int i = 0; i < CONCURRENT_REQUESTS; i++) {
-			executor.submit(() -> {
-				readyLatch.countDown();
-				try {
-					startLatch.await();
-					checkInService.checkIn(testUser);
-				} catch (InterruptedException e) {
-					Thread.currentThread().interrupt();
-				} finally {
-					doneLatch.countDown();
-				}
-			});
-		}
-
-		readyLatch.await();
-		startLatch.countDown();
-		boolean completed = doneLatch.await(30, TimeUnit.SECONDS);
-		executor.shutdown();
-
-		assertThat(completed).isTrue();
+		runConcurrentCheckIns();
 
 		AttendanceStreak result = attendanceStreakJpaRepository.findByUserId(testUser.getId())
 			.orElseThrow();
 		assertThat(result.getStreakCount()).isEqualTo(5);
 		assertThat(result.getLongestStreak()).isEqualTo(5);
 		assertThat(result.getLastCheckinDate()).isEqualTo(today);
+	}
+
+	@Test
+	@DisplayName("완전히 새 유저가 동시에 여러 번 최초 체크인해도 row는 1개만 생성되고 스트릭은 1이다")
+	void checkIn_concurrentFirstEverCheckIn_createsExactlyOneStreakOfOne() throws Exception {
+		// 이 유저는 attendance_streak row가 아예 없는 상태에서 시작한다.
+		runConcurrentCheckIns();
+
+		AttendanceStreak result = attendanceStreakJpaRepository.findByUserId(testUser.getId())
+			.orElseThrow();
+		assertThat(result.getStreakCount()).isEqualTo(1);
+		assertThat(result.getLongestStreak()).isEqualTo(1);
+		assertThat(result.getLastCheckinDate()).isEqualTo(koreaTimeHandler.now());
+	}
+
+	private void runConcurrentCheckIns() throws Exception {
+		ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_REQUESTS);
+		CountDownLatch readyLatch = new CountDownLatch(CONCURRENT_REQUESTS);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		List<Future<?>> futures = new ArrayList<>();
+
+		for (int i = 0; i < CONCURRENT_REQUESTS; i++) {
+			futures.add(executor.submit(() -> {
+				readyLatch.countDown();
+				startLatch.await();
+				checkInService.checkIn(testUser);
+				return null;
+			}));
+		}
+
+		readyLatch.await();
+		startLatch.countDown();
+
+		// future.get()이 각 스레드의 예외를 그대로 전파하므로, 락이 깨져 일부 요청이 실패하면 테스트도 실패한다.
+		for (Future<?> future : futures) {
+			future.get(30, TimeUnit.SECONDS);
+		}
+		executor.shutdown();
 	}
 }

--- a/src/test/java/com/sixpack/dorundorun/feature/attendance/application/CheckInServiceTest.java
+++ b/src/test/java/com/sixpack/dorundorun/feature/attendance/application/CheckInServiceTest.java
@@ -59,7 +59,7 @@ class CheckInServiceTest {
 		assertThat(response.streakCount()).isEqualTo(5);
 		assertThat(response.longestStreak()).isEqualTo(5);
 		assertThat(response.isFirstCheckInToday()).isFalse();
-		verify(attendanceStreakJpaRepository, never()).save(any());
+		verify(attendanceStreakJpaRepository, never()).insertIfAbsent(any(), any());
 	}
 
 	@Test
@@ -78,6 +78,7 @@ class CheckInServiceTest {
 		assertThat(response.streakCount()).isEqualTo(5);
 		assertThat(response.longestStreak()).isEqualTo(5);
 		assertThat(response.isFirstCheckInToday()).isTrue();
+		verify(attendanceStreakJpaRepository, never()).insertIfAbsent(any(), any());
 	}
 
 	@Test
@@ -96,17 +97,26 @@ class CheckInServiceTest {
 		assertThat(response.streakCount()).isEqualTo(1);
 		assertThat(response.longestStreak()).isEqualTo(10);
 		assertThat(response.isFirstCheckInToday()).isTrue();
+		verify(attendanceStreakJpaRepository, never()).insertIfAbsent(any(), any());
 	}
 
 	@Test
 	@DisplayName("처음 체크인하는 유저는 스트릭 1로 새로 생성된다")
 	void checkIn_firstEverCheckIn_createsStreakWithOne() {
-		when(attendanceStreakJpaRepository.findByUserIdForUpdate(1L)).thenReturn(Optional.empty());
-		when(attendanceStreakJpaRepository.save(any(AttendanceStreak.class)))
-			.thenAnswer(invocation -> invocation.getArgument(0));
+		// insertIfAbsent가 만들어낸 직후 상태를 그대로 모킹 (last_checkin_date = 어제, streak/longest = 0)
+		AttendanceStreak upsertedStreak = AttendanceStreak.builder()
+			.user(testUser)
+			.lastCheckinDate(TODAY.minusDays(1))
+			.streakCount(0)
+			.longestStreak(0)
+			.build();
+		when(attendanceStreakJpaRepository.findByUserIdForUpdate(1L))
+			.thenReturn(Optional.empty())
+			.thenReturn(Optional.of(upsertedStreak));
 
 		CheckInResponse response = checkInService.checkIn(testUser);
 
+		verify(attendanceStreakJpaRepository).insertIfAbsent(1L, TODAY.minusDays(1));
 		assertThat(response.streakCount()).isEqualTo(1);
 		assertThat(response.longestStreak()).isEqualTo(1);
 		assertThat(response.isFirstCheckInToday()).isTrue();

--- a/src/test/java/com/sixpack/dorundorun/feature/attendance/application/CheckInServiceTest.java
+++ b/src/test/java/com/sixpack/dorundorun/feature/attendance/application/CheckInServiceTest.java
@@ -1,0 +1,114 @@
+package com.sixpack.dorundorun.feature.attendance.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sixpack.dorundorun.feature.attendance.dao.AttendanceStreakJpaRepository;
+import com.sixpack.dorundorun.feature.attendance.domain.AttendanceStreak;
+import com.sixpack.dorundorun.feature.attendance.dto.response.CheckInResponse;
+import com.sixpack.dorundorun.feature.user.domain.User;
+import com.sixpack.dorundorun.global.utils.KoreaTimeHandler;
+
+@DisplayName("CheckInService 테스트")
+class CheckInServiceTest {
+
+	@Mock
+	private AttendanceStreakJpaRepository attendanceStreakJpaRepository;
+
+	@Mock
+	private KoreaTimeHandler koreaTimeHandler;
+
+	private CheckInService checkInService;
+
+	private User testUser;
+	private static final LocalDate TODAY = LocalDate.of(2026, 7, 23);
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		checkInService = new CheckInService(attendanceStreakJpaRepository, koreaTimeHandler);
+
+		testUser = User.builder().id(1L).build();
+
+		when(koreaTimeHandler.now()).thenReturn(TODAY);
+	}
+
+	@Test
+	@DisplayName("오늘 이미 체크인했다면 스트릭을 변경하지 않고 그대로 응답한다")
+	void checkIn_alreadyCheckedInToday_doesNotChangeStreak() {
+		AttendanceStreak streak = AttendanceStreak.builder()
+			.user(testUser)
+			.lastCheckinDate(TODAY)
+			.streakCount(5)
+			.longestStreak(5)
+			.build();
+		when(attendanceStreakJpaRepository.findByUserIdForUpdate(1L)).thenReturn(Optional.of(streak));
+
+		CheckInResponse response = checkInService.checkIn(testUser);
+
+		assertThat(response.streakCount()).isEqualTo(5);
+		assertThat(response.longestStreak()).isEqualTo(5);
+		assertThat(response.isFirstCheckInToday()).isFalse();
+		verify(attendanceStreakJpaRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("어제 체크인했다면 스트릭이 1 증가한다")
+	void checkIn_checkedInYesterday_incrementsStreak() {
+		AttendanceStreak streak = AttendanceStreak.builder()
+			.user(testUser)
+			.lastCheckinDate(TODAY.minusDays(1))
+			.streakCount(4)
+			.longestStreak(4)
+			.build();
+		when(attendanceStreakJpaRepository.findByUserIdForUpdate(1L)).thenReturn(Optional.of(streak));
+
+		CheckInResponse response = checkInService.checkIn(testUser);
+
+		assertThat(response.streakCount()).isEqualTo(5);
+		assertThat(response.longestStreak()).isEqualTo(5);
+		assertThat(response.isFirstCheckInToday()).isTrue();
+	}
+
+	@Test
+	@DisplayName("그저께 이전에 체크인했다면 스트릭이 1로 리셋된다")
+	void checkIn_gapInAttendance_resetsStreakToOne() {
+		AttendanceStreak streak = AttendanceStreak.builder()
+			.user(testUser)
+			.lastCheckinDate(TODAY.minusDays(3))
+			.streakCount(10)
+			.longestStreak(10)
+			.build();
+		when(attendanceStreakJpaRepository.findByUserIdForUpdate(1L)).thenReturn(Optional.of(streak));
+
+		CheckInResponse response = checkInService.checkIn(testUser);
+
+		assertThat(response.streakCount()).isEqualTo(1);
+		assertThat(response.longestStreak()).isEqualTo(10);
+		assertThat(response.isFirstCheckInToday()).isTrue();
+	}
+
+	@Test
+	@DisplayName("처음 체크인하는 유저는 스트릭 1로 새로 생성된다")
+	void checkIn_firstEverCheckIn_createsStreakWithOne() {
+		when(attendanceStreakJpaRepository.findByUserIdForUpdate(1L)).thenReturn(Optional.empty());
+		when(attendanceStreakJpaRepository.save(any(AttendanceStreak.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		CheckInResponse response = checkInService.checkIn(testUser);
+
+		assertThat(response.streakCount()).isEqualTo(1);
+		assertThat(response.longestStreak()).isEqualTo(1);
+		assertThat(response.isFirstCheckInToday()).isTrue();
+	}
+}

--- a/src/test/java/com/sixpack/dorundorun/feature/attendance/dto/response/CheckInResponseSerializationTest.java
+++ b/src/test/java/com/sixpack/dorundorun/feature/attendance/dto/response/CheckInResponseSerializationTest.java
@@ -1,0 +1,27 @@
+package com.sixpack.dorundorun.feature.attendance.dto.response;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@DisplayName("CheckInResponse 직렬화 테스트")
+class CheckInResponseSerializationTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	@DisplayName("isFirstCheckInToday가 접두어(is)가 벗겨지지 않고 그대로 직렬화된다")
+	void serialize_keepsIsPrefixOnBooleanField() throws Exception {
+		CheckInResponse response = new CheckInResponse(5, 12, true);
+
+		String json = objectMapper.writeValueAsString(response);
+
+		assertThat(json).contains("\"streakCount\":5");
+		assertThat(json).contains("\"longestStreak\":12");
+		assertThat(json).contains("\"isFirstCheckInToday\":true");
+		assertThat(json).doesNotContain("\"firstCheckInToday\"");
+	}
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #161
>관련 이슈 번호를 할당해주세요
>
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요.
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

iOS 팀 요청으로 "연속 방문 스트릭(출석 체크인)" 기능을 추가합니다. 토스 만보기·듀오링고 스트릭처럼 "오늘 방문했는지"를 서버에 저장해, 앱 재설치나 기기 변경으로 스트릭이 초기화되지 않도록 합니다.

- 앱이 포그라운드로 돌아올 때마다 체크인 API를 호출하고, 서버가 KST 자정 기준으로 마지막 체크인 날짜를 판단해 스트릭을 유지·증가·리셋합니다.
- 하루에 여러 번 호출돼도 스트릭은 1만 증가해야 합니다(idempotent).

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

- `feature/attendance` 패키지 신규 추가 (`AttendanceStreak` 엔티티, `AttendanceStreakJpaRepository`, `CheckInService`, `AttendanceApi`/`AttendanceController`, `CheckInResponse`)
- `POST /api/attendance/check-in` 엔드포인트 추가 (인증 필요, 요청 바디 없음)
  - 응답: `streakCount`, `longestStreak`, `isFirstCheckInToday`
- 날짜 판단은 전적으로 서버 시간(KST)만 사용, 기존 `KoreaTimeHandler` 재사용
- 하루 여러 번 호출되는 동시 요청에도 스트릭이 정확히 1만 증가하도록 `PESSIMISTIC_WRITE` 락을 이 리포지토리에만 국소적으로 도입
- `WithdrawService`에 `deleteAttendanceStreak(userId)` 추가 — 회원 탈퇴 시 스트릭 데이터도 함께 삭제

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요

동시성 통합 테스트(`CheckInConcurrencyIntegrationTest`)를 작성하는 과정에서, 테스트가 생성한 유저/스트릭 row를 정리하지 않으면 같은 Testcontainers MySQL을 공유하는 `NotificationIntegrationTest`의 `userRepository.deleteAll()`이 FK 위반으로 깨지는 것을 발견해 `@AfterEach` 정리 로직을 추가했습니다. 기능 자체와는 무관한 테스트 위생 수정입니다.

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요

- 이 코드베이스에는 지금까지 낙관적/비관적 락 사용 전례가 없었는데, 이번에 `AttendanceStreakJpaRepository.findByUserIdForUpdate`에 `PESSIMISTIC_WRITE`를 처음 도입했습니다. "하루에 몇 번을 호출해도 1만 증가"라는 요구사항 때문에 필요하다고 판단했는데, 다른 방식(낙관적 락 + 재시도, 원자적 UPDATE 쿼리 등)이 더 낫다고 생각되시면 의견 부탁드립니다.
- 신규 유저의 최초 체크인 시 `lastCheckinDate`를 `LocalDate.MIN`으로 초기화한 뒤 곧바로 리셋 분기를 태워 `streak=1`로 정정하는 방식을 썼습니다. 컬럼을 `nullable=false`로 유지하기 위한 선택인데, sentinel 값 대신 nullable 컬럼 + null 체크 방식이 더 낫다고 보시면 편하게 코멘트 주세요.

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요

- `CheckInServiceTest` (단위, Mockito): 오늘 이미 체크인(무변화) / 어제 체크인(+1) / 공백 발생(리셋) / 최초 체크인(신규 생성) — 4개 케이스
- `CheckInConcurrencyIntegrationTest` (통합, Testcontainers MySQL): 동일 유저에 대해 10개 스레드가 동시에 체크인해도 스트릭이 정확히 +1만 되는지 검증
- 전체 테스트 스위트 48/48 통과 확인 (기존 테스트 회귀 없음)
- `application-local.yml`/`application-prod.yml` 모두 `ddl-auto: update`라 별도 마이그레이션 스크립트는 필요 없지만, 배포 후 `SHOW CREATE TABLE attendance_streak;`로 `uk_attendance_streak_user` 유니크 키가 실제로 생성됐는지 확인이 필요합니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [ ] `POST /api/attendance/check-in` 로컬/Swagger에서 직접 호출해 응답 확인
- [ ] 동시 호출 테스트(`CheckInConcurrencyIntegrationTest`) 통과 확인
- [ ] 배포 후 `attendance_streak` 테이블 및 unique key 생성 여부 확인
- [ ] iOS 팀에 확정 스펙 회신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 로그인한 사용자는 하루 1회 출석 체크인을 할 수 있습니다.
  * 체크인 결과로 현재 연속 출석 일수, 최장 연속 출석 일수, 오늘 첫 출석 여부를 제공합니다.
  * 이미 출석한 날짜는 중복으로 기록이 갱신되지 않습니다.
  * 연속이 끊기면 출석 기록이 새로 시작됩니다.
* **개선**
  * 동시 요청이 발생해도 출석 기록이 정확히 유지됩니다.
  * 회원 탈퇴 시 출석 기록도 함께 삭제됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->